### PR TITLE
Brain Transport Update && other fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Build ogamed osx-arm64
       run: | 
         cd ${{ github.workspace }}/ogame/cmd/ogamed
-        env GOOS=darwin GOARCH=amd64 go build -o ogamed
+        env GOOS=darwin GOARCH=arm64 go build -o ogamed
         cd ${{ github.workspace }}
         mv ${{ github.workspace }}/ogame/cmd/ogamed/ogamed ${{ github.workspace }}/publish/osx-arm64/
         chmod +x ${{ github.workspace }}/publish/osx-arm64/TBot

--- a/TBot.Ogame.Infrastructure/Enums/SendFleetCode.cs
+++ b/TBot.Ogame.Infrastructure/Enums/SendFleetCode.cs
@@ -9,6 +9,7 @@ namespace TBot.Ogame.Infrastructure.Enums {
 		GenericError = 0,
 		AfterSleepTime = -1,
 		NotEnoughSlots = -2,
-		QuickerToWaitForProduction = -3
+		QuickerToWaitForProduction = -3,
+		NotEnoughRessources = -4
 	}
 }

--- a/TBot.Ogame.Infrastructure/Models/EspionageReport.cs
+++ b/TBot.Ogame.Infrastructure/Models/EspionageReport.cs
@@ -112,9 +112,32 @@ namespace TBot.Ogame.Infrastructure.Models {
 		/// Get whether or not the scanned planet has any defence (either ships or defence) against an attack.
 		/// </summary>
 		/// <returns>Returns true if the target is defenceless, false otherwise.</returns>
-		public bool IsDefenceless() {
-			if (HasDefensesInformation && HasFleetInformation) {
+		public bool IsDefenceless(bool isUsingProbes = false) {
+			if (HasDefensesInformation && HasFleetInformation && !isUsingProbes) {
 				return LightFighter == null
+					&& HeavyFighter == null
+					&& Cruiser == null
+					&& Battleship == null
+					&& Battlecruiser == null
+					&& Bomber == null
+					&& Destroyer == null
+					&& Deathstar == null
+					&& SmallCargo == null
+					&& LargeCargo == null
+					&& Recycler == null
+					&& Reaper == null
+					&& Pathfinder == null
+					&& RocketLauncher == null
+					&& LightLaser == null
+					&& HeavyLaser == null
+					&& GaussCannon == null
+					&& IonCannon == null
+					&& PlasmaTurret == null
+					&& SmallShieldDome == null
+					&& LargeShieldDome == null;
+			} else if (HasDefensesInformation && HasFleetInformation && isUsingProbes) {
+				return SolarSatellite == null
+					&& LightFighter == null
 					&& HeavyFighter == null
 					&& Cruiser == null
 					&& Battleship == null

--- a/TBot.Ogame.Infrastructure/Models/RankSlotsPriority.cs
+++ b/TBot.Ogame.Infrastructure/Models/RankSlotsPriority.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using TBot.Ogame.Infrastructure.Enums;
+
+namespace TBot.Ogame.Infrastructure.Models {
+	public class RankSlotsPriority {
+		public RankSlotsPriority(Feature feature = Feature.Null, int rank = int.MaxValue, bool active = false, int maxSlots = 0, int slotsUsed = 0) {
+            Rank = rank < 1 ? int.MaxValue : rank;
+            Active = active;
+            MaxSlots = maxSlots;
+            SlotsUsed = slotsUsed;
+            Feature = feature;
+        }
+		public int Rank { get; set; }
+		public bool Active { get; set; }
+		public int MaxSlots { get; set; }
+		public int SlotsUsed { get; set; }
+		public Feature Feature { get; set; }
+        public bool HasPriorityOn(RankSlotsPriority feature) {
+			return this.Rank < feature.Rank;
+		}
+		public override string ToString() {
+			return $"{Rank} -- {Feature.ToString()} is {Active}, using {SlotsUsed}/{MaxSlots}";
+		}
+	}
+
+}

--- a/TBot/Includes/CalculationService.cs
+++ b/TBot/Includes/CalculationService.cs
@@ -4806,5 +4806,16 @@ namespace Tbot.Includes {
 				.Where(planet => (planet as Planet).Temperature.Max >= minTemperature && (planet as Planet).Temperature.Max <= maxTemperature)
 				.Count();
 		}
+
+		public bool	IsThereMoonHere(List<Celestial> planets, Celestial celestial) {
+			Celestial moon = planets.Unique()
+				.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+				.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+				.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+				.Where(c => c.Coordinate.Type == Celestials.Moon)
+				.SingleOrDefault() ?? new() { ID = 0 };
+
+			return moon.ID == 0 ? false: true;
+		}
 	}
 }

--- a/TBot/Includes/ICalculationService.cs
+++ b/TBot/Includes/ICalculationService.cs
@@ -152,6 +152,7 @@ namespace Tbot.Includes {
 		bool ShouldAbandon(Planet celestial, int maxCases, int Temperature, Fields fieldsSettings, Temperature temperaturesSettings);
 		int CountPlanetsInRange(List<Planet> planets, int galaxy, int minSystem, int maxSystem, int minPosition, int maxPositions, int minSlots, int minTemperature, int maxTemperature);
 		int CountPlanetsInRange(List<Celestial> planets, int galaxy, int minSystem, int maxSystem, int minPosition, int maxPositions, int minSlots, int minTemperature, int maxTemperature);
+		bool IsThereMoonHere(List<Celestial> planets, Celestial celestial);
 
 	}
 

--- a/TBot/Workers/AutoDiscoveryWorker.cs
+++ b/TBot/Workers/AutoDiscoveryWorker.cs
@@ -97,11 +97,11 @@ namespace Tbot.Workers {
 						fleet.Mission != Missions.Colonize &&
 						fleet.Mission != Missions.Discovery)
 					).Count();
-					_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+					//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
 					foreach (RankSlotsPriority feature in rankSlotsPriority) {
 						if (feature == presentFeature)
 							continue;
-						_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+						//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
 						if (feature.Active && feature.HasPriorityOn(presentFeature)) {
 							msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
 							reservedSlots += feature.MaxSlots;

--- a/TBot/Workers/AutoDiscoveryWorker.cs
+++ b/TBot/Workers/AutoDiscoveryWorker.cs
@@ -232,11 +232,11 @@ namespace Tbot.Workers {
 					DoLog(LogLevel.Information, $"Stopping feature.");
 					await EndExecution();
 				} else {
-					long interval = (_tbotInstance.UserData.fleets.OrderBy(f => f.BackIn).First().BackIn ?? 0) * 1000 + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
+					long interval = (_tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).OrderByDescending(f => f.BackIn).First().BackIn ?? 0) * 1000 + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
 					if (delay) {
 						DoLog(LogLevel.Information, $"Delaying...");
 						_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
-						interval = interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.AutoDiscovery.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.AutoDiscovery.CheckIntervalMax);
+						interval = (_tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).OrderByDescending(f => f.BackIn).First().BackIn ?? 0) * 1000 + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
 					}
 					if (interval <= 0)
 						interval = RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);

--- a/TBot/Workers/AutoFarmWorker.cs
+++ b/TBot/Workers/AutoFarmWorker.cs
@@ -632,11 +632,11 @@ namespace Tbot.Workers {
 							fleet.Mission != Missions.Colonize &&
 							fleet.Mission != Missions.Discovery)
 						).Count();
-					_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+					//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
 					foreach (RankSlotsPriority feature in rankSlotsPriority) {
 						if (feature == presentFeature)
 							continue;
-						_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+						//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
 						if (feature.Active && feature.HasPriorityOn(presentFeature)) {
 							msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
 							reservedSlots += feature.MaxSlots;

--- a/TBot/Workers/AutoFarmWorker.cs
+++ b/TBot/Workers/AutoFarmWorker.cs
@@ -1012,6 +1012,9 @@ namespace Tbot.Workers {
 							continue;
 						}
 
+						Buildables cargoShip;
+						Enum.TryParse<Buildables>((string) _tbotInstance.InstanceSettings.AutoFarm.CargoType, true, out cargoShip);
+						bool isUsingProbes = cargoShip == Buildables.EspionageProbe && _tbotInstance.UserData.serverData.ProbeCargo == 1 ? true : false;
 						newFarmTarget.Report = report;
 						if (_tbotInstance.InstanceSettings.AutoFarm.PreferedResource == "Metal" && report.Loot(_tbotInstance.UserData.userInfo.Class).Metal > _tbotInstance.InstanceSettings.AutoFarm.MinimumResources
 							|| _tbotInstance.InstanceSettings.AutoFarm.PreferedResource == "Crystal" && report.Loot(_tbotInstance.UserData.userInfo.Class).Crystal > _tbotInstance.InstanceSettings.AutoFarm.MinimumResources
@@ -1026,7 +1029,7 @@ namespace Tbot.Workers {
 									newFarmTarget.State = FarmState.ProbesRequired;
 
 								_tbotInstance.log(LogLevel.Information, LogSender.AutoFarm, $"Need more probes on {report.Coordinate}. Loot: {report.Loot(_tbotInstance.UserData.userInfo.Class)}");
-							} else if (report.IsDefenceless()) {
+							} else if (report.IsDefenceless(isUsingProbes)) {
 								newFarmTarget.State = FarmState.AttackPending;
 								_tbotInstance.log(LogLevel.Information, LogSender.AutoFarm, $"Attack pending on {report.Coordinate}. Loot: {report.Loot(_tbotInstance.UserData.userInfo.Class)}");
 							} else {

--- a/TBot/Workers/Brain/AutoMineCelestialWorker.cs
+++ b/TBot/Workers/Brain/AutoMineCelestialWorker.cs
@@ -438,6 +438,7 @@ namespace Tbot.Workers.Brain {
 													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
 													.Where(planet => planet.Coordinate.Type == Celestials.Moon)
 													.First();
+												missingResources = xCostBuildable.Difference(destination.Resources);
 											} else {
 												destination = allCelestials
 													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
@@ -446,6 +447,7 @@ namespace Tbot.Workers.Brain {
 													.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
 													.First();
 											}
+											closestCelestials = closestCelestials.Where(c => !c.Coordinate.IsSame(destination.Coordinate)).ToList();
 											if (_calculationService.IsThereTransportTowardsCelestial(destination, _tbotInstance.UserData.fleets)) {
 												DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {destination.ToString()}");
 												return;
@@ -502,6 +504,7 @@ namespace Tbot.Workers.Brain {
 
 											if (resultOrigins.Count > MaxSlots) {
 												DoLog(LogLevel.Information, $"Not enough slots available to send all resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Slots needed: {resultOrigins.Count().ToString()}/{MaxSlots}.");
+												delay = true;
 												return;
 											}
 											
@@ -567,6 +570,8 @@ namespace Tbot.Workers.Brain {
 								} else {
 									DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
 								}
+							} else {
+								delay = true;
 							}
 						}
 					}

--- a/TBot/Workers/Brain/AutoMineCelestialWorker.cs
+++ b/TBot/Workers/Brain/AutoMineCelestialWorker.cs
@@ -302,27 +302,271 @@ namespace Tbot.Workers.Brain {
 							DoLog(LogLevel.Information, $"Not enough resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.TransportableResources} - Available: {celestial.Resources.TransportableResources}");
 						}
 						if ((bool) _tbotInstance.InstanceSettings.Brain.AutoMine.Transports.Active && (bool) _tbotInstance.InstanceSettings.Brain.Transports.Active) {
+							_tbotInstance.UserData.slots = await _tbotOgameBridge.UpdateSlots();
 							_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
-							if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
-								Celestial origin = _tbotInstance.UserData.celestials
-										.Unique()
-										.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
-										.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
-										.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
-										.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
-										.SingleOrDefault() ?? new() { ID = 0 };
-								fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, buildable, maxBuildings, maxFacilities, maxLunarFacilities, autoMinerSettings);
+							List<RankSlotsPriority> rankSlotsPriority = new();
+							RankSlotsPriority BrainRank = new(Feature.BrainAutoMine,
+								(int) _tbotInstance.InstanceSettings.Brain.SlotPriorityLevel,
+								((bool) _tbotInstance.InstanceSettings.Brain.Active &&
+									(bool) _tbotInstance.InstanceSettings.Brain.Transports.Active && 
+									((bool) _tbotInstance.InstanceSettings.Brain.AutoMine.Active ||
+										(bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Active ||
+										(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Active ||
+										(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Active)),
+								(int) _tbotInstance.InstanceSettings.Brain.Transports.MaxSlots,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Transport).Count());
+							RankSlotsPriority ExpeditionsRank = new(Feature.Expeditions,
+								(int) _tbotInstance.InstanceSettings.Expeditions.SlotPriorityLevel,
+								(bool) _tbotInstance.InstanceSettings.Expeditions.Active,
+								(int) _tbotInstance.UserData.slots.ExpTotal,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Expedition).Count());
+							RankSlotsPriority AutoFarmRank = new(Feature.AutoFarm,
+								(int) _tbotInstance.InstanceSettings.AutoFarm.SlotPriorityLevel,
+								(bool) _tbotInstance.InstanceSettings.AutoFarm.Active,
+								(int) _tbotInstance.InstanceSettings.AutoFarm.MaxSlots,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Attack).Count());
+							RankSlotsPriority ColonizeRank = new(Feature.Colonize,
+								(int) _tbotInstance.InstanceSettings.AutoColonize.SlotPriorityLevel,
+								(bool) _tbotInstance.InstanceSettings.AutoColonize.Active,
+								(bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active ?
+									(int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots :
+									1,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Colonize).Count());
+							RankSlotsPriority AutoDiscoveryRank = new(Feature.AutoDiscovery,
+								(int) _tbotInstance.InstanceSettings.AutoDiscovery.SlotPriorityLevel,
+								(bool) _tbotInstance.InstanceSettings.AutoDiscovery.Active,
+								(int) _tbotInstance.InstanceSettings.AutoDiscovery.MaxSlots,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).Count());
+							RankSlotsPriority presentFeature = BrainRank;
+							rankSlotsPriority.Add(BrainRank);
+							rankSlotsPriority.Add(ExpeditionsRank);
+							rankSlotsPriority.Add(AutoFarmRank);
+							rankSlotsPriority.Add(ColonizeRank);
+							rankSlotsPriority.Add(AutoDiscoveryRank);
+							rankSlotsPriority = rankSlotsPriority.OrderBy(r => r.Rank).ToList();
+							string msg = "";
+							int reservedSlots = 0;
+							int MaxSlots = presentFeature.MaxSlots - presentFeature.SlotsUsed;
+							int otherSlots = (int) _tbotInstance.UserData.fleets.Where(fleet => (fleet.Mission != Missions.Transport &&
+									fleet.Mission != Missions.Expedition &&
+									fleet.Mission != Missions.Attack &&
+									fleet.Mission != Missions.Spy &&
+									fleet.Mission != Missions.Colonize &&
+									fleet.Mission != Missions.Discovery)
+								).Count();
+							_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+							foreach (RankSlotsPriority feature in rankSlotsPriority) {
+								if (feature == presentFeature)
+									continue;
+								_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+								if (feature.Active && feature.HasPriorityOn(presentFeature)) {
+									msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
+									reservedSlots += feature.MaxSlots;
+								} else {
+									otherSlots += feature.SlotsUsed;
+								}
+							}
+							if (otherSlots > 0)
+								msg = $"{msg}, {otherSlots} are used for Other";
+							int tempsValue = _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree - reservedSlots - otherSlots - presentFeature.SlotsUsed;
+							tempsValue = tempsValue < 0 ? 0 : tempsValue;
+							DoLog(LogLevel.Information, $"{presentFeature.MaxSlots} slots are reserved for {presentFeature.Feature.ToString()}. Total slots: {_tbotInstance.UserData.slots.Total}. {_tbotInstance.InstanceSettings.General.SlotsToLeaveFree} must remain free{msg}, {tempsValue} are availables");
+							if (reservedSlots + otherSlots + presentFeature.SlotsUsed > _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree) {
+								DoLog(LogLevel.Information, $"Unable to send fleet for {presentFeature.Feature.ToString()}, too many slots are already used/reserved");
+								MaxSlots = 0;
+							} else if (MaxSlots > tempsValue) {
+								MaxSlots = tempsValue;
+								DoLog(LogLevel.Information, $"Less slots available than {presentFeature.Feature.ToString()}, many slots are already used/reserved -> steping back to {MaxSlots} instead of {presentFeature.MaxSlots}");
+							}
 
-								if (fleetId == (int) SendFleetCode.AfterSleepTime) {
-									stop = true;
-									return;
+							if (MaxSlots > 0) {
+								if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {								
+									Celestial origin;
+									if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.CheckMoonOrPlanetFirst && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial)) {
+										origin = _tbotInstance.UserData.celestials
+												.Unique()
+												.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+												.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+												.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+												.Where(c => c.Coordinate.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+												.SingleOrDefault() ?? new() { ID = 0 };
+												fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, buildable, maxBuildings, maxFacilities, maxLunarFacilities, autoMinerSettings);
+										if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+											stop = true;
+										}
+										if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+											delay = true;
+										}
+									}
+
+									if (fleetId <= 0) {
+										if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.Active) {
+											var resultOrigins = new Dictionary<Celestial, Resources>();
+											List<Celestial> allCelestials = _tbotInstance.UserData.celestials;
+											List<Celestial> celestialsToExclude = _calculationService.ParseCelestialsList(_tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.Exclude, allCelestials);
+											for (int i = 0; i < allCelestials.Count(); i++) {
+												allCelestials[i] = await _tbotOgameBridge.UpdatePlanet(allCelestials[i], UpdateTypes.Resources);
+												allCelestials[i] = await _tbotOgameBridge.UpdatePlanet(allCelestials[i], UpdateTypes.Ships);
+											}
+											List<Celestial> closestCelestials = (bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.OnlyFromMoons ?
+												allCelestials
+													.Where(planet => !celestialsToExclude.Has(planet))
+													.Where(planet => planet.Resources.TotalResources > 0)
+													.Where(planet => planet.Resources.Deuterium > (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave)
+													.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+													.OrderByDescending(planet => planet.Coordinate.Type == Celestials.Moon)
+													.ToList():
+												allCelestials
+													.Where(c => !celestialsToExclude.Has(c))
+													.Where(c => c.Resources.TotalResources > 0)
+													.Where(c => c.Resources.Deuterium > (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave)
+													.ToList();
+
+											closestCelestials = (bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.PriorityToProximityOverQuantity ?
+												closestCelestials.OrderBy(c => _calculationService.CalcDistance(c.Coordinate, celestial.Coordinate, _tbotInstance.UserData.serverData)).ToList() :
+												closestCelestials.OrderByDescending(c => c.Resources.TotalResources).ToList();
+
+											Resources missingResources = xCostBuildable.Difference(celestial.Resources);
+											Resources resourcesTotalAvailable = new();
+											Resources possibleResources = new();
+
+											Celestial destination;
+											if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.SendToTheMoonIfPossible && celestial.Coordinate.Type == Celestials.Planet && _calculationService.IsThereMoonHere(allCelestials, celestial) && (!celestial.Ships.IsEmpty() || celestial.Resources.TotalResources > 0)) {
+												destination = allCelestials
+													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+													.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+													.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+													.First();
+											} else {
+												destination = allCelestials
+													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+													.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+													.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
+													.First();
+											}
+											if (_calculationService.IsThereTransportTowardsCelestial(destination, _tbotInstance.UserData.fleets)) {
+												DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {destination.ToString()}");
+												return;
+											}
+
+											Buildables preferredShip = Buildables.SmallCargo;
+											if (!Enum.TryParse<Buildables>((string) _tbotInstance.InstanceSettings.Brain.Transports.CargoType, true, out preferredShip)) {
+												_tbotInstance.log(LogLevel.Warning, LogSender.FleetScheduler, "Unable to parse CargoType. Falling back to default SmallCargo");
+												preferredShip = Buildables.SmallCargo;
+											}
+											long idealShips;
+
+											foreach (var possibleOrigin in closestCelestials) {
+												//if (!celestialsToExclude.Has(possibleOrigin))			// if .Where(planet => !celestialsToExclude.Has(planet)) don't work
+												if (!_calculationService.IsThereTransportTowardsCelestial(possibleOrigin, _tbotInstance.UserData.fleets))
+													possibleResources = possibleResources.Sum(possibleOrigin.Resources);
+											}
+											if (!possibleResources.IsEnoughFor(xCostBuildable)) {
+												possibleResources = possibleResources.Sum(celestial.Resources);
+												DoLog(LogLevel.Information, $"Not enough resources available on all celestials to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.TransportableResources} - Available: {possibleResources.TransportableResources}");
+												return;
+											}
+											
+											Celestial moonDestination = new();
+											foreach (var possibleOrigin in closestCelestials) {
+												possibleResources = new();
+												Celestial tempPossibleOrigin = possibleOrigin;
+												tempPossibleOrigin.Resources.Deuterium = (tempPossibleOrigin.Resources.Deuterium - (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave) > 0 ? tempPossibleOrigin.Resources.Deuterium - (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave : 0;
+												if (tempPossibleOrigin.Resources.Metal < missingResources.Metal - resourcesTotalAvailable.Metal)
+													possibleResources.Metal = tempPossibleOrigin.Resources.Metal;
+												else
+													possibleResources.Metal = missingResources.Metal - resourcesTotalAvailable.Metal;
+												if (tempPossibleOrigin.Resources.Crystal < missingResources.Crystal - resourcesTotalAvailable.Crystal)
+													possibleResources.Crystal = tempPossibleOrigin.Resources.Crystal;
+												else
+													possibleResources.Crystal = missingResources.Crystal - resourcesTotalAvailable.Crystal;
+												if (tempPossibleOrigin.Resources.Deuterium < missingResources.Deuterium - resourcesTotalAvailable.Deuterium)
+													possibleResources.Deuterium = tempPossibleOrigin.Resources.Deuterium;
+												else
+													possibleResources.Deuterium = missingResources.Deuterium - resourcesTotalAvailable.Deuterium;
+
+												idealShips = _calculationService.CalcShipNumberForPayload(possibleResources, preferredShip, _tbotInstance.UserData.researches.HyperspaceTechnology, _tbotInstance.UserData.serverData, celestial.LFBonuses.GetShipCargoBonus(preferredShip), _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo);
+												if (idealShips > possibleOrigin.Ships.GetAmount(preferredShip) ||
+													possibleResources.TotalResources <= (long) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.MinimumResourcesToSend ||
+													_calculationService.IsThereTransportTowardsCelestial(tempPossibleOrigin, _tbotInstance.UserData.fleets))
+														continue;
+												
+												resourcesTotalAvailable = resourcesTotalAvailable.Sum(possibleResources);
+												resultOrigins.Add(tempPossibleOrigin, possibleResources);
+												_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{tempPossibleOrigin.ToString()} add with {possibleResources.TotalResources} - ({resultOrigins.Count}) {_calculationService.IsThereTransportTowardsCelestial(tempPossibleOrigin, _tbotInstance.UserData.fleets)}");
+												if (resourcesTotalAvailable.IsEnoughFor(missingResources))
+													break;
+											}
+
+											if (resultOrigins.Count > MaxSlots) {
+												DoLog(LogLevel.Information, $"Not enough slots available to send all resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Slots needed: {resultOrigins.Count().ToString()}/{MaxSlots}.");
+												return;
+											}
+											
+											possibleResources = new();
+											foreach (var (originMultiple, resourcesValue) in resultOrigins) {
+												possibleResources = possibleResources.Sum(resourcesValue);
+											}
+											if (!possibleResources.IsEnoughFor(missingResources)) {
+												possibleResources = possibleResources.Sum(celestial.Resources);
+												DoLog(LogLevel.Information, $"Not enough cargo available on all celestials to transport resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.TransportableResources} - Available: {possibleResources.TransportableResources}");
+												return;
+											}
+
+											Ships ships = new();
+											var fleetID = 0;
+											foreach (var (originMultiple, resourcesValue) in resultOrigins) {
+												ships = new();
+												ships.Add(preferredShip, _calculationService.CalcShipNumberForPayload(resourcesValue, preferredShip, _tbotInstance.UserData.researches.HyperspaceTechnology, _tbotInstance.UserData.serverData, celestial.LFBonuses.GetShipCargoBonus(preferredShip), _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo));
+												
+												fleetID = await _fleetScheduler.SendFleet(originMultiple, ships, destination.Coordinate, Missions.Transport, Speeds.HundredPercent, resourcesValue);
+
+												if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+													stop = true;
+													return;
+												}
+												if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+													return;
+												}
+											}
+										} else {
+											Celestial destination;
+											if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.SendToTheMoonIfPossible && celestial.Coordinate.Type == Celestials.Planet && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial) && (!celestial.Ships.IsEmpty() || celestial.Resources.TotalResources > 0)) {
+												destination = _tbotInstance.UserData.celestials
+													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+													.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+													.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+													.First();
+											} else {
+												destination = _tbotInstance.UserData.celestials
+													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+													.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+													.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
+													.First();
+											}
+											origin = _tbotInstance.UserData.celestials
+												.Unique()
+												.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
+												.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
+												.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
+												.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
+												.SingleOrDefault() ?? new() { ID = 0 };
+											fleetId = await _fleetScheduler.HandleMinerTransport(origin, destination, xCostBuildable, buildable, maxBuildings, maxFacilities, maxLunarFacilities, autoMinerSettings);
+											if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+												stop = true;
+											}
+											if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+												delay = true;
+											}
+										}
+									}
+								} else {
+									DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
 								}
-								if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
-									delay = true;
-									return;
-								}
-							} else {
-								DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
 							}
 						}
 					}
@@ -415,14 +659,24 @@ namespace Tbot.Workers.Brain {
 
 				} else {
 					long interval = await CalcAutoMineTimer(celestial, buildable, level, started, maxBuildings, maxFacilities, maxLunarFacilities, autoMinerSettings);
-
-					if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
-						_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
+					if (fleetId > 0) {
+						_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();							
 						var transportfleet = _tbotInstance.UserData.fleets.Single(f => f.ID == fleetId && f.Mission == Missions.Transport);
 						interval = (transportfleet.ArriveIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
-
 					} else {
-						interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.Brain.AutoMine.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.Brain.AutoMine.CheckIntervalMax);
+						interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.CheckIntervalMax);
+					}
+					if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.DoMultipleTransportIsNotEnoughShipButSamePosition) {
+						var transportfleet2 = _tbotInstance.UserData.fleets.Where(f => f.Mission == Missions.Transport)
+							.Where(f => f.Destination.IsSame(celestial.Coordinate))
+							.Where(f => f.Origin.Galaxy == celestial.Coordinate.Galaxy)
+							.Where(f => f.Origin.System == celestial.Coordinate.System)
+							.Where(f => f.Origin.Position == celestial.Coordinate.Position)
+							.Where(f => f.Origin.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+							.ToList();
+						if (transportfleet2.Count() > 0) {
+							interval = (long) (transportfleet2.First().BackIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
+						}
 					}
 
 					if (interval == long.MaxValue || interval == long.MinValue)
@@ -525,17 +779,19 @@ namespace Tbot.Workers.Brain {
 									.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
 									.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
 									.SingleOrDefault() ?? new() { ID = 0 };
-							var returningExpoOrigin = _calculationService.GetFirstReturningExpedition(origin.Coordinate, _tbotInstance.UserData.fleets);
-							if (returningExpoOrigin != null) {
-								returningExpoOriginTime = (long) (returningExpoOrigin.BackIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.AMinuteOrTwo);
-								//DoLog(LogLevel.Debug, $"Next expedition returning in transport origin celestial by {now.AddMilliseconds(returningExpoOriginTime).ToString()}");
-							}
+							if (origin.ID != 0) {
+								var returningExpoOrigin = _calculationService.GetFirstReturningExpedition(origin.Coordinate, _tbotInstance.UserData.fleets);
+								if (returningExpoOrigin != null) {
+									returningExpoOriginTime = (long) (returningExpoOrigin.BackIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.AMinuteOrTwo);
+									//DoLog(LogLevel.Debug, $"Next expedition returning in transport origin celestial by {now.AddMilliseconds(returningExpoOriginTime).ToString()}");
+								}
 
-							var incomingOriginFleets = _calculationService.GetIncomingFleetsWithResources(origin, _tbotInstance.UserData.fleets);
-							if (incomingOriginFleets.Any()) {
-								var fleet = incomingOriginFleets.First();
-								transportOriginTime = ((fleet.Mission == Missions.Transport || fleet.Mission == Missions.Deploy) && !fleet.ReturnFlight ? (long) fleet.ArriveIn : (long) fleet.BackIn) * 1000;
-								//DoLog(LogLevel.Debug, $"Next fleet with resources arriving in transport origin celestial by {DateTime.Now.AddMilliseconds(transportOriginTime).ToString()}");
+								var incomingOriginFleets = _calculationService.GetIncomingFleetsWithResources(origin, _tbotInstance.UserData.fleets);
+								if (incomingOriginFleets.Any()) {
+									var fleet = incomingOriginFleets.First();
+									transportOriginTime = ((fleet.Mission == Missions.Transport || fleet.Mission == Missions.Deploy) && !fleet.ReturnFlight ? (long) fleet.ArriveIn : (long) fleet.BackIn) * 1000;
+									//DoLog(LogLevel.Debug, $"Next fleet with resources arriving in transport origin celestial by {DateTime.Now.AddMilliseconds(transportOriginTime).ToString()}");
+								}
 							}
 						}
 

--- a/TBot/Workers/Brain/AutoMineCelestialWorker.cs
+++ b/TBot/Workers/Brain/AutoMineCelestialWorker.cs
@@ -354,11 +354,11 @@ namespace Tbot.Workers.Brain {
 									fleet.Mission != Missions.Colonize &&
 									fleet.Mission != Missions.Discovery)
 								).Count();
-							_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+							//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
 							foreach (RankSlotsPriority feature in rankSlotsPriority) {
 								if (feature == presentFeature)
 									continue;
-								_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+								//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
 								if (feature.Active && feature.HasPriorityOn(presentFeature)) {
 									msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
 									reservedSlots += feature.MaxSlots;

--- a/TBot/Workers/Brain/AutoMineWorker.cs
+++ b/TBot/Workers/Brain/AutoMineWorker.cs
@@ -110,15 +110,15 @@ namespace Tbot.Workers.Brain {
 					cel = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.LFBuildings);
 					cel = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.LFBonuses);					
 					Planet abaCelestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Fast) as Planet;
-
-					//var nextMine = _calculationService.GetNextMineToBuild(cel as Planet, _tbotInstance.UserData.researches, _tbotInstance.UserData.serverData.Speed, (int) _tbotInstance.InstanceSettings.Brain.AutoMine.MaxMetalMine, (int)  _tbotInstance.InstanceSettings.Brain.AutoMine.MaxCrystalMine, (int)  _tbotInstance.InstanceSettings.Brain.AutoMine.MaxDeuteriumSynthetizer, 1, _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.staff.Geologist, _tbotInstance.UserData.staff.IsFull, true, int.MaxValue);
-					var nextMine = _calculationService.GetNextMineToBuild(cel as Planet, _tbotInstance.UserData.researches, _tbotInstance.UserData.serverData.Speed, int.MaxValue, int.MaxValue, int.MaxValue, 1, _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.staff.Geologist, _tbotInstance.UserData.staff.IsFull, true, int.MaxValue);
-					var lv = _calculationService.GetNextLevel(cel, nextMine);
-					var DOIR = _calculationService.CalcNextDaysOfInvestmentReturn(cel as Planet, _tbotInstance.UserData.researches, _tbotInstance.UserData.serverData.Speed, 1, _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.staff.Geologist, _tbotInstance.UserData.staff.IsFull);
-					DoLog(LogLevel.Debug, $"Celestial {cel.ToString()}: Next Mine: {nextMine.ToString()} lv {lv.ToString()}; DOIR: {DOIR.ToString()}.");
-					if (DOIR < _tbotInstance.UserData.nextDOIR || _tbotInstance.UserData.nextDOIR == 0) {
-						_tbotInstance.UserData.nextDOIR = DOIR;
-					}					
+					var nextMine = _calculationService.GetNextMineToBuild(cel as Planet, _tbotInstance.UserData.researches, _tbotInstance.UserData.serverData.Speed, maxBuildings.MetalMine, maxBuildings.CrystalMine, maxBuildings.DeuteriumSynthesizer, 1, _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.staff.Geologist, _tbotInstance.UserData.staff.IsFull, true, int.MaxValue);
+					if (nextMine != Buildables.Null) {
+						var lv = _calculationService.GetNextLevel(cel, nextMine);
+						var DOIR = _calculationService.CalcNextDaysOfInvestmentReturn(cel as Planet, _tbotInstance.UserData.researches, _tbotInstance.UserData.serverData.Speed, 1, _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.staff.Geologist, _tbotInstance.UserData.staff.IsFull);
+						DoLog(LogLevel.Debug, $"Celestial {cel.ToString()}: Next Mine: {nextMine.ToString()} lv {lv.ToString()}; DOIR: {DOIR.ToString()}.");
+						if (DOIR < _tbotInstance.UserData.nextDOIR || _tbotInstance.UserData.nextDOIR == 0) {
+							_tbotInstance.UserData.nextDOIR = DOIR;
+						}
+					}
 					if (celestial.Coordinate.Type == Celestials.Planet && celestial.Fields.Built == 0 && (bool) _tbotInstance.InstanceSettings.AutoColonize.Abandon.Active) {
 						if (_calculationService.ShouldAbandon(celestial as Planet, celestial.Fields.Total, abaCelestial.Temperature.Max, fieldsSettings, temperaturesSettings)) {
 							DoLog(LogLevel.Debug, $"Skipping {celestial.ToString()}: planet should be abandoned.");

--- a/TBot/Workers/Brain/AutoResearchWorker.cs
+++ b/TBot/Workers/Brain/AutoResearchWorker.cs
@@ -90,6 +90,8 @@ namespace Tbot.Workers.Brain {
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Facilities) as Planet;
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Resources) as Planet;
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.ResourcesProduction) as Planet;
+				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.LFBonuses) as Planet;
+				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Ships) as Planet;
 
 				Buildables research;
 
@@ -161,6 +163,7 @@ namespace Tbot.Workers.Brain {
 				int level = _calculationService.GetNextLevel(_tbotInstance.UserData.researches, research);
 				if (research != Buildables.Null) {
 					celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Resources) as Planet;
+					celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Ships) as Planet;
 					Resources cost = _calculationService.CalcPrice(research, level);
 					if (celestial.Resources.IsEnoughFor(cost)) {
 						try {
@@ -172,35 +175,281 @@ namespace Tbot.Workers.Brain {
 					} else {
 						DoLog(LogLevel.Information, $"Not enough resources to build: {research.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {cost.TransportableResources} - Available: {celestial.Resources.TransportableResources}");
 						if ((bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Transports.Active && (bool) _tbotInstance.InstanceSettings.Brain.Transports.Active) {
+							_tbotInstance.UserData.slots = await _tbotOgameBridge.UpdateSlots();
 							_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
-							if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
-								Celestial origin = _tbotInstance.UserData.celestials
-									.Unique()
-									.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
-									.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
-									.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
-									.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
-									.SingleOrDefault() ?? new() { ID = 0 };
-								fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, cost, Buildables.Null);
-								if (fleetId == (int) SendFleetCode.AfterSleepTime) {
-									stop = true;
+							List<RankSlotsPriority> rankSlotsPriority = new();
+							RankSlotsPriority BrainRank = new(Feature.BrainAutoResearch,
+								(int) _tbotInstance.InstanceSettings.Brain.SlotPriorityLevel,
+								((bool) _tbotInstance.InstanceSettings.Brain.Active &&
+									(bool) _tbotInstance.InstanceSettings.Brain.Transports.Active && 
+									((bool) _tbotInstance.InstanceSettings.Brain.AutoMine.Active ||
+										(bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Active ||
+										(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Active ||
+										(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Active)),
+								(int) _tbotInstance.InstanceSettings.Brain.Transports.MaxSlots,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Transport).Count());
+							RankSlotsPriority ExpeditionsRank = new(Feature.Expeditions,
+								(int) _tbotInstance.InstanceSettings.Expeditions.SlotPriorityLevel,
+								(bool) _tbotInstance.InstanceSettings.Expeditions.Active,
+								(int) _tbotInstance.UserData.slots.ExpTotal,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Expedition).Count());
+							RankSlotsPriority AutoFarmRank = new(Feature.AutoFarm,
+								(int) _tbotInstance.InstanceSettings.AutoFarm.SlotPriorityLevel,
+								(bool) _tbotInstance.InstanceSettings.AutoFarm.Active,
+								(int) _tbotInstance.InstanceSettings.AutoFarm.MaxSlots,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Attack).Count());
+							RankSlotsPriority ColonizeRank = new(Feature.Colonize,
+								(int) _tbotInstance.InstanceSettings.AutoColonize.SlotPriorityLevel,
+								(bool) _tbotInstance.InstanceSettings.AutoColonize.Active,
+								(bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active ?
+									(int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots :
+									1,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Colonize).Count());
+							RankSlotsPriority AutoDiscoveryRank = new(Feature.AutoDiscovery,
+								(int) _tbotInstance.InstanceSettings.AutoDiscovery.SlotPriorityLevel,
+								(bool) _tbotInstance.InstanceSettings.AutoDiscovery.Active,
+								(int) _tbotInstance.InstanceSettings.AutoDiscovery.MaxSlots,
+								(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).Count());
+							RankSlotsPriority presentFeature = BrainRank;
+							rankSlotsPriority.Add(BrainRank);
+							rankSlotsPriority.Add(ExpeditionsRank);
+							rankSlotsPriority.Add(AutoFarmRank);
+							rankSlotsPriority.Add(ColonizeRank);
+							rankSlotsPriority.Add(AutoDiscoveryRank);
+							rankSlotsPriority = rankSlotsPriority.OrderBy(r => r.Rank).ToList();
+							string msg = "";
+							int reservedSlots = 0;
+							int MaxSlots = presentFeature.MaxSlots - presentFeature.SlotsUsed;
+							int otherSlots = (int) _tbotInstance.UserData.fleets.Where(fleet => (fleet.Mission != Missions.Transport &&
+									fleet.Mission != Missions.Expedition &&
+									fleet.Mission != Missions.Attack &&
+									fleet.Mission != Missions.Spy &&
+									fleet.Mission != Missions.Colonize &&
+									fleet.Mission != Missions.Discovery)
+								).Count();
+							_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+							foreach (RankSlotsPriority feature in rankSlotsPriority) {
+								if (feature == presentFeature)
+									continue;
+								_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+								if (feature.Active && feature.HasPriorityOn(presentFeature)) {
+									msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
+									reservedSlots += feature.MaxSlots;
+								} else {
+									otherSlots += feature.SlotsUsed;
 								}
-								if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
-									delay = true;
+							}
+							if (otherSlots > 0)
+								msg = $"{msg}, {otherSlots} are used for Other";
+							int tempsValue = _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree - reservedSlots - otherSlots - presentFeature.SlotsUsed;
+							tempsValue = tempsValue < 0 ? 0 : tempsValue;
+							DoLog(LogLevel.Information, $"{presentFeature.MaxSlots} slots are reserved for {presentFeature.Feature.ToString()}. Total slots: {_tbotInstance.UserData.slots.Total}. {_tbotInstance.InstanceSettings.General.SlotsToLeaveFree} must remain free{msg}, {tempsValue} are availables");
+							if (reservedSlots + otherSlots > _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree) {
+								DoLog(LogLevel.Information, $"Unable to send fleet for {presentFeature.Feature.ToString()}, too many slots are already used/reserved");
+								MaxSlots = 0;
+							} else if (MaxSlots > tempsValue) {
+								MaxSlots = tempsValue;
+								DoLog(LogLevel.Information, $"Less slots available than {presentFeature.Feature.ToString()}, many slots are already used/reserved -> steping back to {MaxSlots} instead of {presentFeature.MaxSlots}");
+							}
+
+							if (MaxSlots > 0) {
+								if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
+									Celestial origin;
+									if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.CheckMoonOrPlanetFirst && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial)) {
+										origin = _tbotInstance.UserData.celestials
+												.Unique()
+												.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+												.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+												.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+												.Where(c => c.Coordinate.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+												.SingleOrDefault() ?? new() { ID = 0 };
+										fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, cost, Buildables.Null);
+										if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+											stop = true;
+										}
+										if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+											delay = true;
+										}
+									}
+
+									if (fleetId <= 0) {
+										if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.Active) {
+											var resultOrigins = new Dictionary<Celestial, Resources>();
+											List<Celestial> allCelestials = _tbotInstance.UserData.celestials;
+											List<Celestial> celestialsToExclude = _calculationService.ParseCelestialsList(_tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.Exclude, allCelestials);
+											for (int i = 0; i < allCelestials.Count(); i++) {
+												allCelestials[i] = await _tbotOgameBridge.UpdatePlanet(allCelestials[i], UpdateTypes.Resources);
+												allCelestials[i] = await _tbotOgameBridge.UpdatePlanet(allCelestials[i], UpdateTypes.Ships);
+											}
+											List<Celestial> closestCelestials = (bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.OnlyFromMoons ?
+												allCelestials
+													.Where(planet => !celestialsToExclude.Has(planet))
+													.Where(planet => planet.Resources.TotalResources > 0)
+													.Where(planet => planet.Resources.Deuterium > (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave)
+													.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+													.OrderByDescending(planet => planet.Coordinate.Type == Celestials.Moon)
+													.ToList():
+												allCelestials
+													.Where(c => !celestialsToExclude.Has(c))
+													.Where(c => c.Resources.TotalResources > 0)
+													.Where(c => c.Resources.Deuterium > (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave)
+													.ToList();
+
+											closestCelestials = (bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.PriorityToProximityOverQuantity ?
+												closestCelestials.OrderBy(c => _calculationService.CalcDistance(c.Coordinate, celestial.Coordinate, _tbotInstance.UserData.serverData)).ToList() :
+												closestCelestials.OrderByDescending(c => c.Resources.TotalResources).ToList();
+
+											Resources missingResources = cost.Difference(celestial.Resources);
+											Resources resourcesTotalAvailable = new();
+											Resources possibleResources = new();
+
+											Celestial destination;
+											if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.SendToTheMoonIfPossible && celestial.Coordinate.Type == Celestials.Planet && _calculationService.IsThereMoonHere(allCelestials, celestial) && (!celestial.Ships.IsEmpty() || celestial.Resources.TotalResources > 0)) {
+												destination = allCelestials
+													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+													.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+													.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+													.First();
+											} else {
+												destination = allCelestials
+													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+													.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+													.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
+													.First();
+											}
+											if (_calculationService.IsThereTransportTowardsCelestial(destination, _tbotInstance.UserData.fleets)) {
+												DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {destination.ToString()}");
+												return;
+											}
+
+											Buildables preferredShip = Buildables.SmallCargo;
+											if (!Enum.TryParse<Buildables>((string) _tbotInstance.InstanceSettings.Brain.Transports.CargoType, true, out preferredShip)) {
+												_tbotInstance.log(LogLevel.Warning, LogSender.FleetScheduler, "Unable to parse CargoType. Falling back to default SmallCargo");
+												preferredShip = Buildables.SmallCargo;
+											}
+											long idealShips;
+
+											foreach (var possibleOrigin in closestCelestials) {
+												//if (!celestialsToExclude.Has(possibleOrigin))			// if .Where(planet => !celestialsToExclude.Has(planet)) don't work
+												if (!_calculationService.IsThereTransportTowardsCelestial(possibleOrigin, _tbotInstance.UserData.fleets))
+													possibleResources = possibleResources.Sum(possibleOrigin.Resources);
+											}
+											if (!possibleResources.IsEnoughFor(cost)) {
+												possibleResources = possibleResources.Sum(celestial.Resources);
+												DoLog(LogLevel.Information, $"Not enough resources available on all celestials to build: {research.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {cost.TransportableResources} - Available: {possibleResources.TransportableResources}");
+												return;
+											}
+											
+											Celestial moonDestination = new();
+											foreach (var possibleOrigin in closestCelestials) {
+												possibleResources = new();
+												Celestial tempPossibleOrigin = possibleOrigin;
+												tempPossibleOrigin.Resources.Deuterium = (tempPossibleOrigin.Resources.Deuterium - (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave) > 0 ? tempPossibleOrigin.Resources.Deuterium - (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave : 0;
+												if (tempPossibleOrigin.Resources.Metal < missingResources.Metal - resourcesTotalAvailable.Metal)
+													possibleResources.Metal = tempPossibleOrigin.Resources.Metal;
+												else
+													possibleResources.Metal = missingResources.Metal - resourcesTotalAvailable.Metal;
+												if (tempPossibleOrigin.Resources.Crystal < missingResources.Crystal - resourcesTotalAvailable.Crystal)
+													possibleResources.Crystal = tempPossibleOrigin.Resources.Crystal;
+												else
+													possibleResources.Crystal = missingResources.Crystal - resourcesTotalAvailable.Crystal;
+												if (tempPossibleOrigin.Resources.Deuterium < missingResources.Deuterium - resourcesTotalAvailable.Deuterium)
+													possibleResources.Deuterium = tempPossibleOrigin.Resources.Deuterium;
+												else
+													possibleResources.Deuterium = missingResources.Deuterium - resourcesTotalAvailable.Deuterium;
+
+												idealShips = _calculationService.CalcShipNumberForPayload(possibleResources, preferredShip, _tbotInstance.UserData.researches.HyperspaceTechnology, _tbotInstance.UserData.serverData, celestial.LFBonuses.GetShipCargoBonus(preferredShip), _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo);
+												if (idealShips > possibleOrigin.Ships.GetAmount(preferredShip) ||
+													possibleResources.TotalResources <= (long) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.MinimumResourcesToSend ||
+													_calculationService.IsThereTransportTowardsCelestial(tempPossibleOrigin, _tbotInstance.UserData.fleets))
+														continue;
+												
+												resourcesTotalAvailable = resourcesTotalAvailable.Sum(possibleResources);
+												resultOrigins.Add(tempPossibleOrigin, possibleResources);
+												_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{tempPossibleOrigin.ToString()} add with {possibleResources.TotalResources} - ({resultOrigins.Count}) {_calculationService.IsThereTransportTowardsCelestial(tempPossibleOrigin, _tbotInstance.UserData.fleets)}");
+												if (resourcesTotalAvailable.IsEnoughFor(missingResources))
+													break;
+											}
+
+											if (resultOrigins.Count > MaxSlots) {
+												DoLog(LogLevel.Information, $"Not enough slots available to send all resources to build: {research.ToString()} level {level.ToString()} on {celestial.ToString()}. Slots needed: {resultOrigins.Count().ToString()}/{MaxSlots}.");
+												return;
+											}
+											
+											possibleResources = new();
+											foreach (var (originMultiple, resourcesValue) in resultOrigins) {
+												possibleResources = possibleResources.Sum(resourcesValue);
+											}
+											if (!possibleResources.IsEnoughFor(missingResources)) {
+												possibleResources = possibleResources.Sum(celestial.Resources);
+												DoLog(LogLevel.Information, $"Not enough cargo available on all celestials to transport resources to build: {research.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {cost.TransportableResources} - Available: {possibleResources.TransportableResources}");
+												return;
+											}
+
+											Ships ships = new();
+											var fleetID = 0;
+											foreach (var (originMultiple, resourcesValue) in resultOrigins) {
+												ships = new();
+												ships.Add(preferredShip, _calculationService.CalcShipNumberForPayload(resourcesValue, preferredShip, _tbotInstance.UserData.researches.HyperspaceTechnology, _tbotInstance.UserData.serverData, celestial.LFBonuses.GetShipCargoBonus(preferredShip), _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo));
+												
+												fleetID = await _fleetScheduler.SendFleet(originMultiple, ships, destination.Coordinate, Missions.Transport, Speeds.HundredPercent, resourcesValue);
+
+												if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+													stop = true;
+													return;
+												}
+												if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+													return;
+												}
+											}
+										} else {
+											Celestial destination;
+											if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.SendToTheMoonIfPossible && celestial.Coordinate.Type == Celestials.Planet && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial) && (!celestial.Ships.IsEmpty() || celestial.Resources.TotalResources > 0)) {
+												destination = _tbotInstance.UserData.celestials
+													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+													.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+													.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+													.First();
+											} else {
+												destination = _tbotInstance.UserData.celestials
+													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+													.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+													.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
+													.First();
+											}
+											origin = _tbotInstance.UserData.celestials
+												.Unique()
+												.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
+												.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
+												.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
+												.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
+												.SingleOrDefault() ?? new() { ID = 0 };
+											fleetId = await _fleetScheduler.HandleMinerTransport(origin, destination, cost, Buildables.Null);											if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+												stop = true;
+											}
+											if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+												delay = true;
+											}
+										}
+									}
+								} else {
+									DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
+									fleetId = (_tbotInstance.UserData.fleets
+										.Where(f => f.Mission == Missions.Transport)
+										.Where(f => f.Resources.TotalResources > 0)
+										.Where(f => f.ReturnFlight == false)
+										.Where(f => f.Destination.Galaxy == celestial.Coordinate.Galaxy)
+										.Where(f => f.Destination.System == celestial.Coordinate.System)
+										.Where(f => f.Destination.Position == celestial.Coordinate.Position)
+										.Where(f => f.Destination.Type == celestial.Coordinate.Type)
+										.OrderByDescending(f => f.ArriveIn)
+										.FirstOrDefault() ?? new() { ID = 0 })
+										.ID;
 								}
-							} else {
-								DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
-								fleetId = (_tbotInstance.UserData.fleets
-									.Where(f => f.Mission == Missions.Transport)
-									.Where(f => f.Resources.TotalResources > 0)
-									.Where(f => f.ReturnFlight == false)
-									.Where(f => f.Destination.Galaxy == celestial.Coordinate.Galaxy)
-									.Where(f => f.Destination.System == celestial.Coordinate.System)
-									.Where(f => f.Destination.Position == celestial.Coordinate.Position)
-									.Where(f => f.Destination.Type == celestial.Coordinate.Type)
-									.OrderByDescending(f => f.ArriveIn)
-									.FirstOrDefault() ?? new() { ID = 0 })
-									.ID;
 							}
 						}
 					}
@@ -262,7 +511,25 @@ namespace Tbot.Workers.Brain {
 									.First();
 								interval = (((fleet.Mission == Missions.Transport || fleet.Mission == Missions.Deploy) ? (long) fleet.ArriveIn : (long) fleet.BackIn) * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
 							} else {
-								interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.Brain.AutoResearch.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.Brain.AutoResearch.CheckIntervalMax);
+								if (fleetId > 0) {
+									_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();							
+									var transportfleet = _tbotInstance.UserData.fleets.Single(f => f.ID == fleetId && f.Mission == Missions.Transport);
+									interval = (transportfleet.ArriveIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
+								} else {
+									interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.CheckIntervalMax);
+								}
+								if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.DoMultipleTransportIsNotEnoughShipButSamePosition) {
+									var transportfleet2 = _tbotInstance.UserData.fleets.Where(f => f.Mission == Missions.Transport)
+										.Where(f => f.Destination.IsSame(celestial.Coordinate))
+										.Where(f => f.Origin.Galaxy == celestial.Coordinate.Galaxy)
+										.Where(f => f.Origin.System == celestial.Coordinate.System)
+										.Where(f => f.Origin.Position == celestial.Coordinate.Position)
+										.Where(f => f.Origin.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+										.ToList();
+									if (transportfleet2.Count() > 0) {
+										interval = (long) (transportfleet2.First().BackIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
+									}
+								}
 							}
 						}
 						if (interval <= 0)

--- a/TBot/Workers/Brain/AutoResearchWorker.cs
+++ b/TBot/Workers/Brain/AutoResearchWorker.cs
@@ -227,11 +227,11 @@ namespace Tbot.Workers.Brain {
 									fleet.Mission != Missions.Colonize &&
 									fleet.Mission != Missions.Discovery)
 								).Count();
-							_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+							//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
 							foreach (RankSlotsPriority feature in rankSlotsPriority) {
 								if (feature == presentFeature)
 									continue;
-								_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+								//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
 								if (feature.Active && feature.HasPriorityOn(presentFeature)) {
 									msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
 									reservedSlots += feature.MaxSlots;

--- a/TBot/Workers/Brain/AutoResearchWorker.cs
+++ b/TBot/Workers/Brain/AutoResearchWorker.cs
@@ -311,6 +311,7 @@ namespace Tbot.Workers.Brain {
 													.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
 													.Where(planet => planet.Coordinate.Type == Celestials.Moon)
 													.First();
+												missingResources = cost.Difference(destination.Resources);
 											} else {
 												destination = allCelestials
 													.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
@@ -319,6 +320,7 @@ namespace Tbot.Workers.Brain {
 													.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
 													.First();
 											}
+											closestCelestials = closestCelestials.Where(c => !c.Coordinate.IsSame(destination.Coordinate)).ToList();
 											if (_calculationService.IsThereTransportTowardsCelestial(destination, _tbotInstance.UserData.fleets)) {
 												DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {destination.ToString()}");
 												return;
@@ -375,6 +377,7 @@ namespace Tbot.Workers.Brain {
 
 											if (resultOrigins.Count > MaxSlots) {
 												DoLog(LogLevel.Information, $"Not enough slots available to send all resources to build: {research.ToString()} level {level.ToString()} on {celestial.ToString()}. Slots needed: {resultOrigins.Count().ToString()}/{MaxSlots}.");
+												delay = true;
 												return;
 											}
 											
@@ -450,6 +453,8 @@ namespace Tbot.Workers.Brain {
 										.FirstOrDefault() ?? new() { ID = 0 })
 										.ID;
 								}
+							} else {
+								delay = true;
 							}
 						}
 					}

--- a/TBot/Workers/Brain/LifeformsAutoMineCelestialWorker.cs
+++ b/TBot/Workers/Brain/LifeformsAutoMineCelestialWorker.cs
@@ -234,11 +234,11 @@ namespace Tbot.Workers.Brain {
 											fleet.Mission != Missions.Colonize &&
 											fleet.Mission != Missions.Discovery)
 										).Count();
-									_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+									//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
 									foreach (RankSlotsPriority feature in rankSlotsPriority) {
 										if (feature == presentFeature)
 											continue;
-										_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+										//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
 										if (feature.Active && feature.HasPriorityOn(presentFeature)) {
 											msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
 											reservedSlots += feature.MaxSlots;

--- a/TBot/Workers/Brain/LifeformsAutoMineCelestialWorker.cs
+++ b/TBot/Workers/Brain/LifeformsAutoMineCelestialWorker.cs
@@ -101,6 +101,8 @@ namespace Tbot.Workers.Brain {
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.LFBuildings);
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Buildings);
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Constructions);
+				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.LFBonuses);
+				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Ships);
 
 				bool preventTechBuilding = false;
 				if (celestial.Constructions.LFResearchCountdown > 0) {
@@ -180,37 +182,279 @@ namespace Tbot.Workers.Brain {
 								DoLog(LogLevel.Information, $"Not enough resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.LFBuildingCostResources.ToString()} - Available: {celestial.Resources.LFBuildingCostResources.ToString()}");
 
 								if ((bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Transports.Active && (bool) _tbotInstance.InstanceSettings.Brain.Transports.Active) {
+									_tbotInstance.UserData.slots = await _tbotOgameBridge.UpdateSlots();
 									_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
-									if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
-										Celestial origin = _tbotInstance.UserData.celestials
-												.Unique()
-												.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
-												.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
-												.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
-												.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
-												.SingleOrDefault() ?? new() { ID = 0 };
-										fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, buildable, maxLFBuildings, preventIfMoreExpensiveThanNextMine);
-										if (fleetId == (int) SendFleetCode.AfterSleepTime) {
-											stop = true;
-											return;
+									List<RankSlotsPriority> rankSlotsPriority = new();
+									RankSlotsPriority BrainRank = new(Feature.BrainLifeformAutoMine,
+										(int) _tbotInstance.InstanceSettings.Brain.SlotPriorityLevel,
+										((bool) _tbotInstance.InstanceSettings.Brain.Active &&
+											(bool) _tbotInstance.InstanceSettings.Brain.Transports.Active && 
+											((bool) _tbotInstance.InstanceSettings.Brain.AutoMine.Active ||
+												(bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Active ||
+												(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Active ||
+												(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Active)),
+										(int) _tbotInstance.InstanceSettings.Brain.Transports.MaxSlots,
+										(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Transport).Count());
+									RankSlotsPriority ExpeditionsRank = new(Feature.Expeditions,
+										(int) _tbotInstance.InstanceSettings.Expeditions.SlotPriorityLevel,
+										(bool) _tbotInstance.InstanceSettings.Expeditions.Active,
+										(int) _tbotInstance.UserData.slots.ExpTotal,
+										(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Expedition).Count());
+									RankSlotsPriority AutoFarmRank = new(Feature.AutoFarm,
+										(int) _tbotInstance.InstanceSettings.AutoFarm.SlotPriorityLevel,
+										(bool) _tbotInstance.InstanceSettings.AutoFarm.Active,
+										(int) _tbotInstance.InstanceSettings.AutoFarm.MaxSlots,
+										(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Attack).Count());
+									RankSlotsPriority ColonizeRank = new(Feature.Colonize,
+										(int) _tbotInstance.InstanceSettings.AutoColonize.SlotPriorityLevel,
+										(bool) _tbotInstance.InstanceSettings.AutoColonize.Active,
+										(bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active ?
+											(int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots :
+											1,
+										(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Colonize).Count());
+									RankSlotsPriority AutoDiscoveryRank = new(Feature.AutoDiscovery,
+										(int) _tbotInstance.InstanceSettings.AutoDiscovery.SlotPriorityLevel,
+										(bool) _tbotInstance.InstanceSettings.AutoDiscovery.Active,
+										(int) _tbotInstance.InstanceSettings.AutoDiscovery.MaxSlots,
+										(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).Count());
+									RankSlotsPriority presentFeature = BrainRank;
+									rankSlotsPriority.Add(BrainRank);
+									rankSlotsPriority.Add(ExpeditionsRank);
+									rankSlotsPriority.Add(AutoFarmRank);
+									rankSlotsPriority.Add(ColonizeRank);
+									rankSlotsPriority.Add(AutoDiscoveryRank);
+									rankSlotsPriority = rankSlotsPriority.OrderBy(r => r.Rank).ToList();
+									string msg = "";
+									int reservedSlots = 0;
+									int MaxSlots = presentFeature.MaxSlots - presentFeature.SlotsUsed;
+									int otherSlots = (int) _tbotInstance.UserData.fleets.Where(fleet => (fleet.Mission != Missions.Transport &&
+											fleet.Mission != Missions.Expedition &&
+											fleet.Mission != Missions.Attack &&
+											fleet.Mission != Missions.Spy &&
+											fleet.Mission != Missions.Colonize &&
+											fleet.Mission != Missions.Discovery)
+										).Count();
+									_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+									foreach (RankSlotsPriority feature in rankSlotsPriority) {
+										if (feature == presentFeature)
+											continue;
+										_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+										if (feature.Active && feature.HasPriorityOn(presentFeature)) {
+											msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
+											reservedSlots += feature.MaxSlots;
+										} else {
+											otherSlots += feature.SlotsUsed;
 										}
-										if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
-											delay = true;
-											return;
-										}
-									} else {
-										DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
-										try {
+									}
+									if (otherSlots > 0)
+										msg = $"{msg}, {otherSlots} are used for Other";
+									int tempsValue = _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree - reservedSlots - otherSlots - presentFeature.SlotsUsed;
+									tempsValue = tempsValue < 0 ? 0 : tempsValue;
+									DoLog(LogLevel.Information, $"{presentFeature.MaxSlots} slots are reserved for {presentFeature.Feature.ToString()}. Total slots: {_tbotInstance.UserData.slots.Total}. {_tbotInstance.InstanceSettings.General.SlotsToLeaveFree} must remain free{msg}, {tempsValue} are availables");
+									if (reservedSlots + otherSlots > _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree) {
+										DoLog(LogLevel.Information, $"Unable to send fleet for {presentFeature.Feature.ToString()}, too many slots are already used/reserved");
+										MaxSlots = 0;
+									} else if (MaxSlots > tempsValue) {
+										MaxSlots = tempsValue;
+										DoLog(LogLevel.Information, $"Less slots available than {presentFeature.Feature.ToString()}, many slots are already used/reserved -> steping back to {MaxSlots} instead of {presentFeature.MaxSlots}");
+									}
+
+									if (MaxSlots > 0) {
+										if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
+											Celestial origin;
+											if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.CheckMoonOrPlanetFirst && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial)) {
+												origin = _tbotInstance.UserData.celestials
+														.Unique()
+														.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+														.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+														.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+														.Where(c => c.Coordinate.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+														.SingleOrDefault() ?? new() { ID = 0 };
+														fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, buildable, maxLFBuildings, preventIfMoreExpensiveThanNextMine);
+												if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+													stop = true;
+												}
+												if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+													delay = true;
+												}
+											}
+
+											if (fleetId <= 0) {
+												if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.Active) {
+													var resultOrigins = new Dictionary<Celestial, Resources>();
+													List<Celestial> allCelestials = _tbotInstance.UserData.celestials;
+													List<Celestial> celestialsToExclude = _calculationService.ParseCelestialsList(_tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.Exclude, allCelestials);
+													for (int i = 0; i < allCelestials.Count(); i++) {
+														allCelestials[i] = await _tbotOgameBridge.UpdatePlanet(allCelestials[i], UpdateTypes.Resources);
+														allCelestials[i] = await _tbotOgameBridge.UpdatePlanet(allCelestials[i], UpdateTypes.Ships);
+													}
+													List<Celestial> closestCelestials = (bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.OnlyFromMoons ?
+														allCelestials
+															.Where(planet => !celestialsToExclude.Has(planet))
+															.Where(planet => planet.Resources.TotalResources > 0)
+															.Where(planet => planet.Resources.Deuterium > (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave)
+															.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+															.OrderByDescending(planet => planet.Coordinate.Type == Celestials.Moon)
+															.ToList():
+														allCelestials
+															.Where(c => !celestialsToExclude.Has(c))
+															.Where(c => c.Resources.TotalResources > 0)
+															.Where(c => c.Resources.Deuterium > (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave)
+															.ToList();
+
+													closestCelestials = (bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.PriorityToProximityOverQuantity ?
+														closestCelestials.OrderBy(c => _calculationService.CalcDistance(c.Coordinate, celestial.Coordinate, _tbotInstance.UserData.serverData)).ToList() :
+														closestCelestials.OrderByDescending(c => c.Resources.TotalResources).ToList();
+
+													Resources missingResources = xCostBuildable.Difference(celestial.Resources);
+													Resources resourcesTotalAvailable = new();
+													Resources possibleResources = new();
+
+													Celestial destination;
+													if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.SendToTheMoonIfPossible && celestial.Coordinate.Type == Celestials.Planet && _calculationService.IsThereMoonHere(allCelestials, celestial) && (!celestial.Ships.IsEmpty() || celestial.Resources.TotalResources > 0)) {
+														destination = allCelestials
+															.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+															.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+															.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+															.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+															.First();
+													} else {
+														destination = allCelestials
+															.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+															.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+															.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+															.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
+															.First();
+													}
+													if (_calculationService.IsThereTransportTowardsCelestial(destination, _tbotInstance.UserData.fleets)) {
+														DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {destination.ToString()}");
+														return;
+													}
+
+													Buildables preferredShip = Buildables.SmallCargo;
+													if (!Enum.TryParse<Buildables>((string) _tbotInstance.InstanceSettings.Brain.Transports.CargoType, true, out preferredShip)) {
+														_tbotInstance.log(LogLevel.Warning, LogSender.FleetScheduler, "Unable to parse CargoType. Falling back to default SmallCargo");
+														preferredShip = Buildables.SmallCargo;
+													}
+													long idealShips;
+
+													foreach (var possibleOrigin in closestCelestials) {
+														//if (!celestialsToExclude.Has(possibleOrigin))			// if .Where(planet => !celestialsToExclude.Has(planet)) don't work
+														if (!_calculationService.IsThereTransportTowardsCelestial(possibleOrigin, _tbotInstance.UserData.fleets))
+															possibleResources = possibleResources.Sum(possibleOrigin.Resources);
+													}
+													if (!possibleResources.IsEnoughFor(xCostBuildable)) {
+														possibleResources = possibleResources.Sum(celestial.Resources);
+														DoLog(LogLevel.Information, $"Not enough resources available on all celestials to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.TransportableResources} - Available: {possibleResources.TransportableResources}");
+														return;
+													}
+													
+													Celestial moonDestination = new();
+													foreach (var possibleOrigin in closestCelestials) {
+														possibleResources = new();
+														Celestial tempPossibleOrigin = possibleOrigin;
+														tempPossibleOrigin.Resources.Deuterium = (tempPossibleOrigin.Resources.Deuterium - (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave) > 0 ? tempPossibleOrigin.Resources.Deuterium - (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave : 0;
+														if (tempPossibleOrigin.Resources.Metal < missingResources.Metal - resourcesTotalAvailable.Metal)
+															possibleResources.Metal = tempPossibleOrigin.Resources.Metal;
+														else
+															possibleResources.Metal = missingResources.Metal - resourcesTotalAvailable.Metal;
+														if (tempPossibleOrigin.Resources.Crystal < missingResources.Crystal - resourcesTotalAvailable.Crystal)
+															possibleResources.Crystal = tempPossibleOrigin.Resources.Crystal;
+														else
+															possibleResources.Crystal = missingResources.Crystal - resourcesTotalAvailable.Crystal;
+														if (tempPossibleOrigin.Resources.Deuterium < missingResources.Deuterium - resourcesTotalAvailable.Deuterium)
+															possibleResources.Deuterium = tempPossibleOrigin.Resources.Deuterium;
+														else
+															possibleResources.Deuterium = missingResources.Deuterium - resourcesTotalAvailable.Deuterium;
+
+														idealShips = _calculationService.CalcShipNumberForPayload(possibleResources, preferredShip, _tbotInstance.UserData.researches.HyperspaceTechnology, _tbotInstance.UserData.serverData, celestial.LFBonuses.GetShipCargoBonus(preferredShip), _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo);
+														if (idealShips > possibleOrigin.Ships.GetAmount(preferredShip) ||
+															possibleResources.TotalResources <= (long) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.MinimumResourcesToSend ||
+															_calculationService.IsThereTransportTowardsCelestial(tempPossibleOrigin, _tbotInstance.UserData.fleets))
+																continue;
+														
+														resourcesTotalAvailable = resourcesTotalAvailable.Sum(possibleResources);
+														resultOrigins.Add(tempPossibleOrigin, possibleResources);
+														_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{tempPossibleOrigin.ToString()} add with {possibleResources.TotalResources} - ({resultOrigins.Count}) {_calculationService.IsThereTransportTowardsCelestial(tempPossibleOrigin, _tbotInstance.UserData.fleets)}");
+														if (resourcesTotalAvailable.IsEnoughFor(missingResources))
+															break;
+													}
+
+													if (resultOrigins.Count > MaxSlots) {
+														DoLog(LogLevel.Information, $"Not enough slots available to send all resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Slots needed: {resultOrigins.Count().ToString()}/{MaxSlots}.");
+														return;
+													}
+													
+													possibleResources = new();
+													foreach (var (originMultiple, resourcesValue) in resultOrigins) {
+														possibleResources = possibleResources.Sum(resourcesValue);
+													}
+													if (!possibleResources.IsEnoughFor(missingResources)) {
+														possibleResources = possibleResources.Sum(celestial.Resources);
+														DoLog(LogLevel.Information, $"Not enough cargo available on all celestials to transport resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.TransportableResources} - Available: {possibleResources.TransportableResources}");
+														return;
+													}
+
+													Ships ships = new();
+													var fleetID = 0;
+													foreach (var (originMultiple, resourcesValue) in resultOrigins) {
+														ships = new();
+														ships.Add(preferredShip, _calculationService.CalcShipNumberForPayload(resourcesValue, preferredShip, _tbotInstance.UserData.researches.HyperspaceTechnology, _tbotInstance.UserData.serverData, celestial.LFBonuses.GetShipCargoBonus(preferredShip), _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo));
+														
+														fleetID = await _fleetScheduler.SendFleet(originMultiple, ships, destination.Coordinate, Missions.Transport, Speeds.HundredPercent, resourcesValue);
+
+														if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+															stop = true;
+															return;
+														}
+														if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+															return;
+														}
+													}
+												} else {
+													Celestial destination;
+													if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.SendToTheMoonIfPossible && celestial.Coordinate.Type == Celestials.Planet && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial) && (!celestial.Ships.IsEmpty() || celestial.Resources.TotalResources > 0)) {
+														destination = _tbotInstance.UserData.celestials
+															.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+															.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+															.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+															.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+															.First();
+													} else {
+														destination = _tbotInstance.UserData.celestials
+															.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+															.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+															.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+															.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
+															.First();
+													}
+													origin = _tbotInstance.UserData.celestials
+														.Unique()
+														.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
+														.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
+														.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
+														.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
+														.SingleOrDefault() ?? new() { ID = 0 };
+													fleetId = await _fleetScheduler.HandleMinerTransport(origin, destination, xCostBuildable, buildable, maxLFBuildings, preventIfMoreExpensiveThanNextMine);
+													if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+														stop = true;
+													}
+													if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+														delay = true;
+													}
+												}
+											}
+										} else {
+											DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
 											fleetId = _tbotInstance.UserData.fleets.Where(f => f.Mission == Missions.Transport)
-											.Where(f => f.Resources.TotalResources > 0)
-											.Where(f => f.ReturnFlight == false)
-											.Where(f => f.Destination.Galaxy == celestial.Coordinate.Galaxy)
-											.Where(f => f.Destination.System == celestial.Coordinate.System)
-											.Where(f => f.Destination.Position == celestial.Coordinate.Position)
-											.Where(f => f.Destination.Type == celestial.Coordinate.Type)
-											.First().ID;
+												.Where(f => f.Resources.TotalResources > 0)
+												.Where(f => f.ReturnFlight == false)
+												.Where(f => f.Destination.Galaxy == celestial.Coordinate.Galaxy)
+												.Where(f => f.Destination.System == celestial.Coordinate.System)
+												.Where(f => f.Destination.Position == celestial.Coordinate.Position)
+												.Where(f => f.Destination.Type == celestial.Coordinate.Type)
+												.First().ID;
 										}
-										catch { }
 									}
 								}
 							}
@@ -283,13 +527,26 @@ namespace Tbot.Workers.Brain {
 								}
 							}
 							interval = productionTime + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
-						}
-						else if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
-							_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
-							var transportfleet = _tbotInstance.UserData.fleets.Single(f => f.ID == fleetId && f.Mission == Missions.Transport);
-							interval = (transportfleet.ArriveIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
 						} else {
-							interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.CheckIntervalMax);
+							if (fleetId > 0) {
+								_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();							
+								var transportfleet = _tbotInstance.UserData.fleets.Single(f => f.ID == fleetId && f.Mission == Missions.Transport);
+								interval = (transportfleet.ArriveIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
+							} else {
+								interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.CheckIntervalMax);
+							}
+							if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.DoMultipleTransportIsNotEnoughShipButSamePosition) {
+								var transportfleet2 = _tbotInstance.UserData.fleets.Where(f => f.Mission == Missions.Transport)
+									.Where(f => f.Destination.IsSame(celestial.Coordinate))
+									.Where(f => f.Origin.Galaxy == celestial.Coordinate.Galaxy)
+									.Where(f => f.Origin.System == celestial.Coordinate.System)
+									.Where(f => f.Origin.Position == celestial.Coordinate.Position)
+									.Where(f => f.Origin.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+									.ToList();
+								if (transportfleet2.Count() > 0) {
+									interval = (long) (transportfleet2.First().BackIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
+								}
+							}
 						}
 					}
 					time = await _tbotOgameBridge.GetDateTime();

--- a/TBot/Workers/Brain/LifeformsAutoMineCelestialWorker.cs
+++ b/TBot/Workers/Brain/LifeformsAutoMineCelestialWorker.cs
@@ -318,6 +318,7 @@ namespace Tbot.Workers.Brain {
 															.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
 															.Where(planet => planet.Coordinate.Type == Celestials.Moon)
 															.First();
+														missingResources = xCostBuildable.Difference(destination.Resources);
 													} else {
 														destination = allCelestials
 															.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
@@ -326,6 +327,7 @@ namespace Tbot.Workers.Brain {
 															.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
 															.First();
 													}
+													closestCelestials = closestCelestials.Where(c => !c.Coordinate.IsSame(destination.Coordinate)).ToList();
 													if (_calculationService.IsThereTransportTowardsCelestial(destination, _tbotInstance.UserData.fleets)) {
 														DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {destination.ToString()}");
 														return;
@@ -382,6 +384,7 @@ namespace Tbot.Workers.Brain {
 
 													if (resultOrigins.Count > MaxSlots) {
 														DoLog(LogLevel.Information, $"Not enough slots available to send all resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Slots needed: {resultOrigins.Count().ToString()}/{MaxSlots}.");
+														delay = true;
 														return;
 													}
 													
@@ -455,6 +458,8 @@ namespace Tbot.Workers.Brain {
 												.Where(f => f.Destination.Type == celestial.Coordinate.Type)
 												.First().ID;
 										}
+									} else {
+										delay = true;
 									}
 								}
 							}

--- a/TBot/Workers/Brain/LifeformsAutoResearchCelestialWorker.cs
+++ b/TBot/Workers/Brain/LifeformsAutoResearchCelestialWorker.cs
@@ -235,11 +235,11 @@ namespace Tbot.Workers.Brain {
 										fleet.Mission != Missions.Colonize &&
 										fleet.Mission != Missions.Discovery)
 									).Count();
-								_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+								//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
 								foreach (RankSlotsPriority feature in rankSlotsPriority) {
 									if (feature == presentFeature)
 										continue;
-									_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+									//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
 									if (feature.Active && feature.HasPriorityOn(presentFeature)) {
 										msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
 										reservedSlots += feature.MaxSlots;

--- a/TBot/Workers/Brain/LifeformsAutoResearchCelestialWorker.cs
+++ b/TBot/Workers/Brain/LifeformsAutoResearchCelestialWorker.cs
@@ -319,6 +319,7 @@ namespace Tbot.Workers.Brain {
 														.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
 														.Where(planet => planet.Coordinate.Type == Celestials.Moon)
 														.First();
+													missingResources = xCostBuildable.Difference(destination.Resources);
 												} else {
 													destination = allCelestials
 														.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
@@ -327,6 +328,7 @@ namespace Tbot.Workers.Brain {
 														.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
 														.First();
 												}
+												closestCelestials = closestCelestials.Where(c => !c.Coordinate.IsSame(destination.Coordinate)).ToList();
 												if (_calculationService.IsThereTransportTowardsCelestial(destination, _tbotInstance.UserData.fleets)) {
 													DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {destination.ToString()}");
 													return;
@@ -383,6 +385,7 @@ namespace Tbot.Workers.Brain {
 
 												if (resultOrigins.Count > MaxSlots) {
 													DoLog(LogLevel.Information, $"Not enough slots available to send all resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Slots needed: {resultOrigins.Count().ToString()}/{MaxSlots}.");
+													delay = true;
 													return;
 												}
 												
@@ -448,6 +451,8 @@ namespace Tbot.Workers.Brain {
 									} else {
 										DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
 									}
+								} else {
+									delay = true;
 								}
 							}
 						}

--- a/TBot/Workers/Brain/LifeformsAutoResearchCelestialWorker.cs
+++ b/TBot/Workers/Brain/LifeformsAutoResearchCelestialWorker.cs
@@ -86,12 +86,15 @@ namespace Tbot.Workers.Brain {
 			bool delayProduction = false;
 			long delayTime = 0;
 			long interval = 0;
+			_tbotInstance.UserData.slots = await _tbotOgameBridge.UpdateSlots();
 			try {
 				DoLog(LogLevel.Information, $"Running Lifeform AutoResearch on {celestial.ToString()}");
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Fast);
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Resources);
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.LFTechs);
 				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Constructions);
+				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.LFBonuses);
+				celestial = await _tbotOgameBridge.UpdatePlanet(celestial, UpdateTypes.Ships);
 
 				int maxResearchLevel = SettingsService.IsSettingSet(_tbotInstance.InstanceSettings.Brain.LifeformAutoResearch, "MaxResearchLevel") ? (int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.MaxResearchLevel : 1;
 				int maxTechs11 = SettingsService.IsSettingSet(_tbotInstance.InstanceSettings.Brain.LifeformAutoResearch, "MaxTechs11") ? (int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.MaxTechs11 : maxResearchLevel;
@@ -180,26 +183,271 @@ namespace Tbot.Workers.Brain {
 							DoLog(LogLevel.Information, $"Not enough resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.LFBuildingCostResources.ToString()} - Available: {celestial.Resources.LFBuildingCostResources.ToString()}");
 
 							if ((bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Transports.Active && (bool) _tbotInstance.InstanceSettings.Brain.Transports.Active) {
+								_tbotInstance.UserData.slots = await _tbotOgameBridge.UpdateSlots();
 								_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
-								if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
-									Celestial origin = _tbotInstance.UserData.celestials
-											.Unique()
-											.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
-											.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
-											.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
-											.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
-											.SingleOrDefault() ?? new() { ID = 0 };
-									fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, Buildables.Null);
-									if (fleetId == (int) SendFleetCode.AfterSleepTime) {
-										stop = true;
-										return;
+								List<RankSlotsPriority> rankSlotsPriority = new();
+								RankSlotsPriority BrainRank = new(Feature.BrainLifeformAutoResearch,
+									(int) _tbotInstance.InstanceSettings.Brain.SlotPriorityLevel,
+									((bool) _tbotInstance.InstanceSettings.Brain.Active &&
+										(bool) _tbotInstance.InstanceSettings.Brain.Transports.Active && 
+										((bool) _tbotInstance.InstanceSettings.Brain.AutoMine.Active ||
+											(bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Active ||
+											(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Active ||
+											(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Active)),
+									(int) _tbotInstance.InstanceSettings.Brain.Transports.MaxSlots,
+									(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Transport).Count());
+								RankSlotsPriority ExpeditionsRank = new(Feature.Expeditions,
+									(int) _tbotInstance.InstanceSettings.Expeditions.SlotPriorityLevel,
+									(bool) _tbotInstance.InstanceSettings.Expeditions.Active,
+									(int) _tbotInstance.UserData.slots.ExpTotal,
+									(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Expedition).Count());
+								RankSlotsPriority AutoFarmRank = new(Feature.AutoFarm,
+									(int) _tbotInstance.InstanceSettings.AutoFarm.SlotPriorityLevel,
+									(bool) _tbotInstance.InstanceSettings.AutoFarm.Active,
+									(int) _tbotInstance.InstanceSettings.AutoFarm.MaxSlots,
+									(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Attack).Count());
+								RankSlotsPriority ColonizeRank = new(Feature.Colonize,
+									(int) _tbotInstance.InstanceSettings.AutoColonize.SlotPriorityLevel,
+									(bool) _tbotInstance.InstanceSettings.AutoColonize.Active,
+									(bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active ?
+										(int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots :
+										1,
+									(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Colonize).Count());
+								RankSlotsPriority AutoDiscoveryRank = new(Feature.AutoDiscovery,
+									(int) _tbotInstance.InstanceSettings.AutoDiscovery.SlotPriorityLevel,
+									(bool) _tbotInstance.InstanceSettings.AutoDiscovery.Active,
+									(int) _tbotInstance.InstanceSettings.AutoDiscovery.MaxSlots,
+									(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).Count());
+								RankSlotsPriority presentFeature = BrainRank;
+								rankSlotsPriority.Add(BrainRank);
+								rankSlotsPriority.Add(ExpeditionsRank);
+								rankSlotsPriority.Add(AutoFarmRank);
+								rankSlotsPriority.Add(ColonizeRank);
+								rankSlotsPriority.Add(AutoDiscoveryRank);
+								rankSlotsPriority = rankSlotsPriority.OrderBy(r => r.Rank).ToList();
+								string msg = "";
+								int reservedSlots = 0;
+								int MaxSlots = presentFeature.MaxSlots - presentFeature.SlotsUsed;
+								int otherSlots = (int) _tbotInstance.UserData.fleets.Where(fleet => (fleet.Mission != Missions.Transport &&
+										fleet.Mission != Missions.Expedition &&
+										fleet.Mission != Missions.Attack &&
+										fleet.Mission != Missions.Spy &&
+										fleet.Mission != Missions.Colonize &&
+										fleet.Mission != Missions.Discovery)
+									).Count();
+								_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+								foreach (RankSlotsPriority feature in rankSlotsPriority) {
+									if (feature == presentFeature)
+										continue;
+									_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+									if (feature.Active && feature.HasPriorityOn(presentFeature)) {
+										msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
+										reservedSlots += feature.MaxSlots;
+									} else {
+										otherSlots += feature.SlotsUsed;
 									}
-									if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
-										delay = true;
-										return;
+								}
+								if (otherSlots > 0)
+									msg = $"{msg}, {otherSlots} are used for Other";
+								int tempsValue = _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree - reservedSlots - otherSlots - presentFeature.SlotsUsed;
+								tempsValue = tempsValue < 0 ? 0 : tempsValue;
+								DoLog(LogLevel.Information, $"{presentFeature.MaxSlots} slots are reserved for {presentFeature.Feature.ToString()}. Total slots: {_tbotInstance.UserData.slots.Total}. {_tbotInstance.InstanceSettings.General.SlotsToLeaveFree} must remain free{msg}, {tempsValue} are availables");
+								if (reservedSlots + otherSlots > _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree) {
+									DoLog(LogLevel.Information, $"Unable to send fleet for {presentFeature.Feature.ToString()}, too many slots are already used/reserved");
+									MaxSlots = 0;
+								} else if (MaxSlots > tempsValue) {
+									MaxSlots = tempsValue;
+									DoLog(LogLevel.Information, $"Less slots available than {presentFeature.Feature.ToString()}, many slots are already used/reserved -> steping back to {MaxSlots} instead of {presentFeature.MaxSlots}");
+								}
+
+								if (MaxSlots > 0) {
+									if (!_calculationService.IsThereTransportTowardsCelestial(celestial, _tbotInstance.UserData.fleets)) {
+										Celestial origin;
+										if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.CheckMoonOrPlanetFirst && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial)) {
+											origin = _tbotInstance.UserData.celestials
+													.Unique()
+													.Where(c => c.Coordinate.Galaxy == (int) celestial.Coordinate.Galaxy)
+													.Where(c => c.Coordinate.System == (int) celestial.Coordinate.System)
+													.Where(c => c.Coordinate.Position == (int) celestial.Coordinate.Position)
+													.Where(c => c.Coordinate.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+													.SingleOrDefault() ?? new() { ID = 0 };
+											fleetId = await _fleetScheduler.HandleMinerTransport(origin, celestial, xCostBuildable, LFBuildables.None);
+											if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+												stop = true;
+											}
+											if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+												delay = true;
+											}
+										}
+
+										if (fleetId <= 0) {
+											if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.Active) {
+												var resultOrigins = new Dictionary<Celestial, Resources>();
+												List<Celestial> allCelestials = _tbotInstance.UserData.celestials;
+												List<Celestial> celestialsToExclude = _calculationService.ParseCelestialsList(_tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.Exclude, allCelestials);
+												for (int i = 0; i < allCelestials.Count(); i++) {
+													allCelestials[i] = await _tbotOgameBridge.UpdatePlanet(allCelestials[i], UpdateTypes.Resources);
+													allCelestials[i] = await _tbotOgameBridge.UpdatePlanet(allCelestials[i], UpdateTypes.Ships);
+												}
+												List<Celestial> closestCelestials = (bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.OnlyFromMoons ?
+													allCelestials
+														.Where(planet => !celestialsToExclude.Has(planet))
+														.Where(planet => planet.Resources.TotalResources > 0)
+														.Where(planet => planet.Resources.Deuterium > (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave)
+														.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+														.OrderByDescending(planet => planet.Coordinate.Type == Celestials.Moon)
+														.ToList():
+													allCelestials
+														.Where(c => !celestialsToExclude.Has(c))
+														.Where(c => c.Resources.TotalResources > 0)
+														.Where(c => c.Resources.Deuterium > (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave)
+														.ToList();
+
+												closestCelestials = (bool) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.PriorityToProximityOverQuantity ?
+													closestCelestials.OrderBy(c => _calculationService.CalcDistance(c.Coordinate, celestial.Coordinate, _tbotInstance.UserData.serverData)).ToList() :
+													closestCelestials.OrderByDescending(c => c.Resources.TotalResources).ToList();
+
+												Resources missingResources = xCostBuildable.Difference(celestial.Resources);
+												Resources resourcesTotalAvailable = new();
+												Resources possibleResources = new();
+
+												Celestial destination;
+												if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.SendToTheMoonIfPossible && celestial.Coordinate.Type == Celestials.Planet && _calculationService.IsThereMoonHere(allCelestials, celestial) && (!celestial.Ships.IsEmpty() || celestial.Resources.TotalResources > 0)) {
+													destination = allCelestials
+														.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+														.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+														.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+														.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+														.First();
+												} else {
+													destination = allCelestials
+														.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+														.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+														.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+														.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
+														.First();
+												}
+												if (_calculationService.IsThereTransportTowardsCelestial(destination, _tbotInstance.UserData.fleets)) {
+													DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {destination.ToString()}");
+													return;
+												}
+
+												Buildables preferredShip = Buildables.SmallCargo;
+												if (!Enum.TryParse<Buildables>((string) _tbotInstance.InstanceSettings.Brain.Transports.CargoType, true, out preferredShip)) {
+													_tbotInstance.log(LogLevel.Warning, LogSender.FleetScheduler, "Unable to parse CargoType. Falling back to default SmallCargo");
+													preferredShip = Buildables.SmallCargo;
+												}
+												long idealShips;
+
+												foreach (var possibleOrigin in closestCelestials) {
+													//if (!celestialsToExclude.Has(possibleOrigin))			// if .Where(planet => !celestialsToExclude.Has(planet)) don't work
+													if (!_calculationService.IsThereTransportTowardsCelestial(possibleOrigin, _tbotInstance.UserData.fleets))
+														possibleResources = possibleResources.Sum(possibleOrigin.Resources);
+												}
+												if (!possibleResources.IsEnoughFor(xCostBuildable)) {
+													possibleResources = possibleResources.Sum(celestial.Resources);
+													DoLog(LogLevel.Information, $"Not enough resources available on all celestials to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.TransportableResources} - Available: {possibleResources.TransportableResources}");
+													return;
+												}
+												
+												Celestial moonDestination = new();
+												foreach (var possibleOrigin in closestCelestials) {
+													possibleResources = new();
+													Celestial tempPossibleOrigin = possibleOrigin;
+													tempPossibleOrigin.Resources.Deuterium = (tempPossibleOrigin.Resources.Deuterium - (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave) > 0 ? tempPossibleOrigin.Resources.Deuterium - (long) _tbotInstance.InstanceSettings.Brain.Transports.DeutToLeave : 0;
+													if (tempPossibleOrigin.Resources.Metal < missingResources.Metal - resourcesTotalAvailable.Metal)
+														possibleResources.Metal = tempPossibleOrigin.Resources.Metal;
+													else
+														possibleResources.Metal = missingResources.Metal - resourcesTotalAvailable.Metal;
+													if (tempPossibleOrigin.Resources.Crystal < missingResources.Crystal - resourcesTotalAvailable.Crystal)
+														possibleResources.Crystal = tempPossibleOrigin.Resources.Crystal;
+													else
+														possibleResources.Crystal = missingResources.Crystal - resourcesTotalAvailable.Crystal;
+													if (tempPossibleOrigin.Resources.Deuterium < missingResources.Deuterium - resourcesTotalAvailable.Deuterium)
+														possibleResources.Deuterium = tempPossibleOrigin.Resources.Deuterium;
+													else
+														possibleResources.Deuterium = missingResources.Deuterium - resourcesTotalAvailable.Deuterium;
+
+													idealShips = _calculationService.CalcShipNumberForPayload(possibleResources, preferredShip, _tbotInstance.UserData.researches.HyperspaceTechnology, _tbotInstance.UserData.serverData, celestial.LFBonuses.GetShipCargoBonus(preferredShip), _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo);
+													if (idealShips > possibleOrigin.Ships.GetAmount(preferredShip) ||
+														possibleResources.TotalResources <= (long) _tbotInstance.InstanceSettings.Brain.Transports.MultipleOrigins.MinimumResourcesToSend ||
+														_calculationService.IsThereTransportTowardsCelestial(tempPossibleOrigin, _tbotInstance.UserData.fleets))
+															continue;
+													
+													resourcesTotalAvailable = resourcesTotalAvailable.Sum(possibleResources);
+													resultOrigins.Add(tempPossibleOrigin, possibleResources);
+													_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{tempPossibleOrigin.ToString()} add with {possibleResources.TotalResources} - ({resultOrigins.Count}) {_calculationService.IsThereTransportTowardsCelestial(tempPossibleOrigin, _tbotInstance.UserData.fleets)}");
+													if (resourcesTotalAvailable.IsEnoughFor(missingResources))
+														break;
+												}
+
+												if (resultOrigins.Count > MaxSlots) {
+													DoLog(LogLevel.Information, $"Not enough slots available to send all resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Slots needed: {resultOrigins.Count().ToString()}/{MaxSlots}.");
+													return;
+												}
+												
+												possibleResources = new();
+												foreach (var (originMultiple, resourcesValue) in resultOrigins) {
+													possibleResources = possibleResources.Sum(resourcesValue);
+												}
+												if (!possibleResources.IsEnoughFor(missingResources)) {
+													possibleResources = possibleResources.Sum(celestial.Resources);
+													DoLog(LogLevel.Information, $"Not enough cargo available on all celestials to transport resources to build: {buildable.ToString()} level {level.ToString()} on {celestial.ToString()}. Needed: {xCostBuildable.TransportableResources} - Available: {possibleResources.TransportableResources}");
+													return;
+												}
+
+												Ships ships = new();
+												var fleetID = 0;
+												foreach (var (originMultiple, resourcesValue) in resultOrigins) {
+													ships = new();
+													ships.Add(preferredShip, _calculationService.CalcShipNumberForPayload(resourcesValue, preferredShip, _tbotInstance.UserData.researches.HyperspaceTechnology, _tbotInstance.UserData.serverData, celestial.LFBonuses.GetShipCargoBonus(preferredShip), _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo));
+													
+													fleetID = await _fleetScheduler.SendFleet(originMultiple, ships, destination.Coordinate, Missions.Transport, Speeds.HundredPercent, resourcesValue);
+
+													if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+														stop = true;
+														return;
+													}
+													if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+														return;
+													}
+												}
+											} else {
+												Celestial destination;
+												if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.SendToTheMoonIfPossible && celestial.Coordinate.Type == Celestials.Planet && _calculationService.IsThereMoonHere(_tbotInstance.UserData.celestials, celestial) && (!celestial.Ships.IsEmpty() || celestial.Resources.TotalResources > 0)) {
+													destination = _tbotInstance.UserData.celestials
+														.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+														.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+														.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+														.Where(planet => planet.Coordinate.Type == Celestials.Moon)
+														.First();
+												} else {
+													destination = _tbotInstance.UserData.celestials
+														.Where(planet => planet.Coordinate.Galaxy == celestial.Coordinate.Galaxy)
+														.Where(planet => planet.Coordinate.System == celestial.Coordinate.System)
+														.Where(planet => planet.Coordinate.Position == celestial.Coordinate.Position)
+														.Where(planet => planet.Coordinate.Type == celestial.Coordinate.Type)
+														.First();
+												}
+												origin = _tbotInstance.UserData.celestials
+													.Unique()
+													.Where(c => c.Coordinate.Galaxy == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Galaxy)
+													.Where(c => c.Coordinate.System == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.System)
+													.Where(c => c.Coordinate.Position == (int) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Position)
+													.Where(c => c.Coordinate.Type == Enum.Parse<Celestials>((string) _tbotInstance.InstanceSettings.Brain.Transports.Origin.Type))
+													.SingleOrDefault() ?? new() { ID = 0 };
+												fleetId = await _fleetScheduler.HandleMinerTransport(origin, destination, xCostBuildable, LFBuildables.None);
+												if (fleetId == (int) SendFleetCode.AfterSleepTime) {
+													stop = true;
+												}
+												if (fleetId == (int) SendFleetCode.NotEnoughSlots) {
+													delay = true;
+												}
+											}
+										}
+									} else {
+										DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
 									}
-								} else {
-									DoLog(LogLevel.Information, $"Skipping transport: there is already a transport incoming in {celestial.ToString()}");
 								}
 							}
 						}
@@ -232,12 +480,24 @@ namespace Tbot.Workers.Brain {
 					} else if (started) {
 						interval = ((long) celestial.Constructions.LFResearchCountdown * (long) 1000) + (long) RandomizeHelper.CalcRandomInterval(IntervalType.AFewSeconds);
 					} else {
-						if (fleetId != 0 && fleetId != -1 && fleetId != -2) {
-							_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
+						if (fleetId > 0) {
+							_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();							
 							var transportfleet = _tbotInstance.UserData.fleets.Single(f => f.ID == fleetId && f.Mission == Missions.Transport);
 							interval = (transportfleet.ArriveIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
 						} else {
-							interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.CheckIntervalMax);
+							interval = RandomizeHelper.CalcRandomInterval((int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.CheckIntervalMin, (int) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.CheckIntervalMax);
+						}
+						if ((bool) _tbotInstance.InstanceSettings.Brain.Transports.DoMultipleTransportIsNotEnoughShipButSamePosition) {
+							var transportfleet2 = _tbotInstance.UserData.fleets.Where(f => f.Mission == Missions.Transport)
+								.Where(f => f.Destination.IsSame(celestial.Coordinate))
+								.Where(f => f.Origin.Galaxy == celestial.Coordinate.Galaxy)
+								.Where(f => f.Origin.System == celestial.Coordinate.System)
+								.Where(f => f.Origin.Position == celestial.Coordinate.Position)
+								.Where(f => f.Origin.Type == (celestial.Coordinate.Type == Celestials.Planet ? Celestials.Moon : Celestials.Planet))
+								.ToList();
+							if (transportfleet2.Count() > 0) {
+								interval = (long) (transportfleet2.First().BackIn * 1000) + RandomizeHelper.CalcRandomInterval(IntervalType.SomeSeconds);
+							}
 						}
 					}
 					

--- a/TBot/Workers/ColonizeWorker.cs
+++ b/TBot/Workers/ColonizeWorker.cs
@@ -150,11 +150,11 @@ namespace Tbot.Workers {
 								fleet.Mission != Missions.Colonize &&
 								fleet.Mission != Missions.Discovery)
 							).Count();
-						_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+						//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
 						foreach (RankSlotsPriority feature in rankSlotsPriority) {
 							if (feature == presentFeature)
 								continue;
-							_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+							//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
 							if (feature.Active && feature.HasPriorityOn(presentFeature)) {
 								msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
 								reservedSlots += feature.MaxSlots;

--- a/TBot/Workers/ColonizeWorker.cs
+++ b/TBot/Workers/ColonizeWorker.cs
@@ -98,7 +98,83 @@ namespace Tbot.Workers {
 					if (currentPlanets + slotsToLeaveFree < maxPlanets) {
 						_tbotInstance.log(LogLevel.Information, LogSender.Colonize, "A new planet is needed.");
 
+						_tbotInstance.UserData.slots = await _tbotOgameBridge.UpdateSlots();
 						_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
+						List<RankSlotsPriority> rankSlotsPriority = new();
+						RankSlotsPriority BrainRank = new(Feature.BrainAutoMine,
+							(int) _tbotInstance.InstanceSettings.Brain.SlotPriorityLevel,
+							((bool) _tbotInstance.InstanceSettings.Brain.Active &&
+								(bool) _tbotInstance.InstanceSettings.Brain.Transports.Active && 
+								((bool) _tbotInstance.InstanceSettings.Brain.AutoMine.Active ||
+									(bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Active ||
+									(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Active ||
+									(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Active)),
+							(int) _tbotInstance.InstanceSettings.Brain.Transports.MaxSlots,
+							(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Transport).Count());
+						RankSlotsPriority ExpeditionsRank = new(Feature.Expeditions,
+							(int) _tbotInstance.InstanceSettings.Expeditions.SlotPriorityLevel,
+							(bool) _tbotInstance.InstanceSettings.Expeditions.Active,
+							(int) _tbotInstance.UserData.slots.ExpTotal,
+							(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Expedition).Count());
+						RankSlotsPriority AutoFarmRank = new(Feature.AutoFarm,
+							(int) _tbotInstance.InstanceSettings.AutoFarm.SlotPriorityLevel,
+							(bool) _tbotInstance.InstanceSettings.AutoFarm.Active,
+							(int) _tbotInstance.InstanceSettings.AutoFarm.MaxSlots,
+							(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Attack).Count());
+						RankSlotsPriority ColonizeRank = new(Feature.Colonize,
+							(int) _tbotInstance.InstanceSettings.AutoColonize.SlotPriorityLevel,
+							(bool) _tbotInstance.InstanceSettings.AutoColonize.Active,
+							(bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active ?
+								(int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots :
+								1,
+							(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Colonize).Count());
+						RankSlotsPriority AutoDiscoveryRank = new(Feature.AutoDiscovery,
+							(int) _tbotInstance.InstanceSettings.AutoDiscovery.SlotPriorityLevel,
+							(bool) _tbotInstance.InstanceSettings.AutoDiscovery.Active,
+							(int) _tbotInstance.InstanceSettings.AutoDiscovery.MaxSlots,
+							(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).Count());
+						RankSlotsPriority presentFeature = ColonizeRank;
+						rankSlotsPriority.Add(BrainRank);
+						rankSlotsPriority.Add(ExpeditionsRank);
+						rankSlotsPriority.Add(AutoFarmRank);
+						rankSlotsPriority.Add(ColonizeRank);
+						rankSlotsPriority.Add(AutoDiscoveryRank);
+						rankSlotsPriority = rankSlotsPriority.OrderBy(r => r.Rank).ToList();
+						string msg = "";
+						int reservedSlots = 0;
+						int MaxSlots = presentFeature.MaxSlots - presentFeature.SlotsUsed;
+						int otherSlots = (int) _tbotInstance.UserData.fleets.Where(fleet => (fleet.Mission != Missions.Transport &&
+								fleet.Mission != Missions.Expedition &&
+								fleet.Mission != Missions.Attack &&
+								fleet.Mission != Missions.Spy &&
+								fleet.Mission != Missions.Colonize &&
+								fleet.Mission != Missions.Discovery)
+							).Count();
+						_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+						foreach (RankSlotsPriority feature in rankSlotsPriority) {
+							if (feature == presentFeature)
+								continue;
+							_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+							if (feature.Active && feature.HasPriorityOn(presentFeature)) {
+								msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
+								reservedSlots += feature.MaxSlots;
+							} else {
+								otherSlots += feature.SlotsUsed;
+							}
+						}
+						if (otherSlots > 0)
+							msg = $"{msg}, {otherSlots} are used for Other";
+						int tempsValue = _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree - reservedSlots - otherSlots - presentFeature.SlotsUsed;
+						tempsValue = tempsValue < 0 ? 0 : tempsValue;
+						DoLog(LogLevel.Information, $"{presentFeature.MaxSlots} slots are reserved for {presentFeature.Feature.ToString()}. Total slots: {_tbotInstance.UserData.slots.Total}. {_tbotInstance.InstanceSettings.General.SlotsToLeaveFree} must remain free{msg}, {tempsValue} are availables");
+						if (reservedSlots + otherSlots > _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree) {
+							DoLog(LogLevel.Information, $"Unable to send fleet for {presentFeature.Feature.ToString()}, too many slots are already used/reserved");
+							MaxSlots = 0;
+						} else if (MaxSlots > tempsValue) {
+							MaxSlots = tempsValue;
+							DoLog(LogLevel.Information, $"Less slots available than {presentFeature.Feature.ToString()}, many slots are already used/reserved -> steping back to {MaxSlots} instead of {presentFeature.MaxSlots}");
+						}
+
 						if (
 							(!(bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active && _tbotInstance.UserData.fleets.Count(f => f.Mission == Missions.Colonize && !f.ReturnFlight) >= maxPlanets - currentPlanets)
 							|| ((bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active && _tbotInstance.UserData.fleets.Count(f => f.Mission == Missions.Colonize && !f.ReturnFlight) > 0)
@@ -169,7 +245,7 @@ namespace Tbot.Workers {
 										}
 										filteredTargets = (bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active
 											? filteredTargetsRdm
-												.Take((int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots)
+												.Take(MaxSlots)
 												.ToList()
 											: filteredTargetsRdm
 												.Take(maxPlanets - currentPlanets)
@@ -178,7 +254,7 @@ namespace Tbot.Workers {
 										filteredTargets = (bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active
 											? filteredTargets
 												.OrderBy(t => _calculationService.CalcDistance(origin.Coordinate, t, _tbotInstance.UserData.serverData))
-												.Take((int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots)
+												.Take(MaxSlots)
 												.ToList()
 											: filteredTargets
 												.OrderBy(t => _calculationService.CalcDistance(origin.Coordinate, t, _tbotInstance.UserData.serverData))

--- a/TBot/Workers/ExpeditionsWorker.cs
+++ b/TBot/Workers/ExpeditionsWorker.cs
@@ -125,11 +125,11 @@ namespace Tbot.Workers {
 							fleet.Mission != Missions.Colonize &&
 							fleet.Mission != Missions.Discovery)
 						).Count();
-					_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+					//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
 					foreach (RankSlotsPriority feature in rankSlotsPriority) {
 						if (feature == presentFeature)
 							continue;
-						_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+						//_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
 						if (feature.Active && feature.HasPriorityOn(presentFeature)) {
 							msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
 							reservedSlots += feature.MaxSlots;

--- a/TBot/Workers/ExpeditionsWorker.cs
+++ b/TBot/Workers/ExpeditionsWorker.cs
@@ -75,6 +75,81 @@ namespace Tbot.Workers {
 					_tbotInstance.UserData.slots = await _tbotOgameBridge.UpdateSlots();
 					_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
 					_tbotInstance.UserData.serverData = await _ogameService.GetServerData();
+					List<RankSlotsPriority> rankSlotsPriority = new();
+					RankSlotsPriority BrainRank = new(Feature.BrainAutoMine,
+						(int) _tbotInstance.InstanceSettings.Brain.SlotPriorityLevel,
+						((bool) _tbotInstance.InstanceSettings.Brain.Active &&
+							(bool) _tbotInstance.InstanceSettings.Brain.Transports.Active && 
+							((bool) _tbotInstance.InstanceSettings.Brain.AutoMine.Active ||
+								(bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Active ||
+								(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Active ||
+								(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Active)),
+						(int) _tbotInstance.InstanceSettings.Brain.Transports.MaxSlots,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Transport).Count());
+					RankSlotsPriority ExpeditionsRank = new(Feature.Expeditions,
+						(int) _tbotInstance.InstanceSettings.Expeditions.SlotPriorityLevel,
+						(bool) _tbotInstance.InstanceSettings.Expeditions.Active,
+						(int) _tbotInstance.UserData.slots.ExpTotal,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Expedition).Count());
+					RankSlotsPriority AutoFarmRank = new(Feature.AutoFarm,
+						(int) _tbotInstance.InstanceSettings.AutoFarm.SlotPriorityLevel,
+						(bool) _tbotInstance.InstanceSettings.AutoFarm.Active,
+						(int) _tbotInstance.InstanceSettings.AutoFarm.MaxSlots,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Attack).Count());
+					RankSlotsPriority ColonizeRank = new(Feature.Colonize,
+						(int) _tbotInstance.InstanceSettings.AutoColonize.SlotPriorityLevel,
+						(bool) _tbotInstance.InstanceSettings.AutoColonize.Active,
+						(bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active ?
+							(int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots :
+							1,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Colonize).Count());
+					RankSlotsPriority AutoDiscoveryRank = new(Feature.AutoDiscovery,
+						(int) _tbotInstance.InstanceSettings.AutoDiscovery.SlotPriorityLevel,
+						(bool) _tbotInstance.InstanceSettings.AutoDiscovery.Active,
+						(int) _tbotInstance.InstanceSettings.AutoDiscovery.MaxSlots,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).Count());
+					RankSlotsPriority presentFeature = ExpeditionsRank;
+					rankSlotsPriority.Add(BrainRank);
+					rankSlotsPriority.Add(ExpeditionsRank);
+					rankSlotsPriority.Add(AutoFarmRank);
+					rankSlotsPriority.Add(ColonizeRank);
+					rankSlotsPriority.Add(AutoDiscoveryRank);
+					rankSlotsPriority = rankSlotsPriority.OrderBy(r => r.Rank).ToList();
+					string msg = "";
+					int reservedSlots = 0;
+					int MaxSlots = presentFeature.MaxSlots - presentFeature.SlotsUsed;
+					int otherSlots = (int) _tbotInstance.UserData.fleets.Where(fleet => (fleet.Mission != Missions.Transport &&
+							fleet.Mission != Missions.Expedition &&
+							fleet.Mission != Missions.Attack &&
+							fleet.Mission != Missions.Spy &&
+							fleet.Mission != Missions.Colonize &&
+							fleet.Mission != Missions.Discovery)
+						).Count();
+					_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+					foreach (RankSlotsPriority feature in rankSlotsPriority) {
+						if (feature == presentFeature)
+							continue;
+						_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+						if (feature.Active && feature.HasPriorityOn(presentFeature)) {
+							msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
+							reservedSlots += feature.MaxSlots;
+						} else {
+							otherSlots += feature.SlotsUsed;
+						}
+					}
+					if (otherSlots > 0)
+						msg = $"{msg}, {otherSlots} are used for Other";
+					int tempsValue = _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree - reservedSlots - otherSlots - presentFeature.SlotsUsed;
+					tempsValue = tempsValue < 0 ? 0 : tempsValue;
+					DoLog(LogLevel.Information, $"{presentFeature.MaxSlots} slots are reserved for {presentFeature.Feature.ToString()}. Total slots: {_tbotInstance.UserData.slots.Total}. {_tbotInstance.InstanceSettings.General.SlotsToLeaveFree} must remain free{msg}, {tempsValue} are availables");
+					if (reservedSlots + otherSlots > _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree) {
+						DoLog(LogLevel.Information, $"Unable to send fleet for {presentFeature.Feature.ToString()}, too many slots are already used/reserved");
+						MaxSlots = 0;
+					} else if (MaxSlots > tempsValue) {
+						MaxSlots = tempsValue;
+						DoLog(LogLevel.Information, $"Less slots available than {presentFeature.Feature.ToString()}, many slots are already used/reserved -> steping back to {MaxSlots} instead of {presentFeature.MaxSlots}");
+					}
+
 					int expsToSend;
 					if (SettingsService.IsSettingSet(_tbotInstance.InstanceSettings.Expeditions, "WaitForAllExpeditions") && (bool) _tbotInstance.InstanceSettings.Expeditions.WaitForAllExpeditions) {
 						if (_tbotInstance.UserData.slots.ExpInUse == 0)
@@ -91,7 +166,7 @@ namespace Tbot.Workers {
 							expsToSend = 0;
 						}
 					}
-
+					expsToSend = expsToSend < MaxSlots ? expsToSend : MaxSlots;
 					if (expsToSend > 0) {
 						if (_tbotInstance.UserData.slots.ExpFree > 0) {
 							if (_tbotInstance.UserData.slots.Free > 0) {
@@ -137,6 +212,8 @@ namespace Tbot.Workers {
 								if ((bool) _tbotInstance.InstanceSettings.Expeditions.RandomizeOrder) {
 									origins = origins.Shuffle().ToList();
 								}
+
+								LFBonuses lfBonuses = origins.First().LFBonuses;
 								Dictionary<Celestial, int> originExps = new();
 								int quot = (int) Math.Floor((float) expsToSend / (float) origins.Count());								
 								foreach (var origin in origins) {
@@ -146,7 +223,6 @@ namespace Tbot.Workers {
 								for (int i = 0; i < rest; i++) {
 									originExps[origins[i]]++;
 								}
-								LFBonuses lfBonuses = origins.First().LFBonuses;
 								int delayExpedition = 0;
 								foreach (var origin in originExps.Keys) {
 									int expsToSendFromThisOrigin = originExps[origin];
@@ -191,7 +267,6 @@ namespace Tbot.Workers {
 											Buildables primaryShip = Buildables.LargeCargo;
 											if (!Enum.TryParse<Buildables>(_tbotInstance.InstanceSettings.Expeditions.PrimaryShip.ToString(), true, out primaryShip)) {
 												DoLog(LogLevel.Warning, "Unable to parse PrimaryShip. Falling back to default LargeCargo");
-												delayExpedition++;
 												primaryShip = Buildables.LargeCargo;
 											}
 											if (primaryShip == Buildables.Null) {

--- a/TBot/Workers/ExpeditionsWorker.cs
+++ b/TBot/Workers/ExpeditionsWorker.cs
@@ -281,8 +281,13 @@ namespace Tbot.Workers {
 											}
 											DoLog(LogLevel.Warning, $"Available {primaryShip.ToString()} in origin {origin.ToString()}: {availableShips.GetAmount(primaryShip)} ({_tbotInstance.InstanceSettings.Expeditions.PrimaryToKeep} must be kept at dock)");
 											fleet = _calculationService.CalcFullExpeditionShips(availableShips, primaryShip, expsToSendFromThisOrigin, _tbotInstance.UserData.serverData, _tbotInstance.UserData.researches, lfBonuses, _tbotInstance.UserData.userInfo.Class, _tbotInstance.UserData.serverData.ProbeCargo);
-											if (fleet.GetAmount(primaryShip) < (long) _tbotInstance.InstanceSettings.Expeditions.MinPrimaryToSend) {
+											if (fleet.GetAmount(primaryShip) < (long) _tbotInstance.InstanceSettings.Expeditions.MinPrimaryToSend || availableShips.GetAmount(primaryShip) < 1) {
 												fleet.SetAmount(primaryShip, (long) _tbotInstance.InstanceSettings.Expeditions.MinPrimaryToSend);
+												if (availableShips.GetAmount(primaryShip) < 1) {
+													DoLog(LogLevel.Warning, $"Unable to send expeditions: no ships available in origin {origin.ToString()}");
+													delayExpedition++;
+													continue;
+												}
 												if (!availableShips.HasAtLeast(fleet, expsToSendFromThisOrigin)) {
 													DoLog(LogLevel.Warning, $"Unable to send expeditions: available {primaryShip.ToString()} in origin {origin.ToString()} under set min number of {(long) _tbotInstance.InstanceSettings.Expeditions.MinPrimaryToSend}");
 													delayExpedition++;

--- a/TBot/Workers/HarvestWorker.cs
+++ b/TBot/Workers/HarvestWorker.cs
@@ -141,9 +141,91 @@ namespace Tbot.Workers {
 						newCelestials.Add(tempCelestial);
 					}
 					_tbotInstance.UserData.celestials = newCelestials;
+					_tbotInstance.UserData.slots = await _tbotOgameBridge.UpdateSlots();
+					_tbotInstance.UserData.fleets = await _fleetScheduler.UpdateFleets();
+					List<RankSlotsPriority> rankSlotsPriority = new();
+					RankSlotsPriority BrainRank = new(Feature.BrainAutoMine,
+						(int) _tbotInstance.InstanceSettings.Brain.SlotPriorityLevel,
+						((bool) _tbotInstance.InstanceSettings.Brain.Active &&
+							(bool) _tbotInstance.InstanceSettings.Brain.Transports.Active && 
+							((bool) _tbotInstance.InstanceSettings.Brain.AutoMine.Active ||
+								(bool) _tbotInstance.InstanceSettings.Brain.AutoResearch.Active ||
+								(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoMine.Active ||
+								(bool) _tbotInstance.InstanceSettings.Brain.LifeformAutoResearch.Active)),
+						(int) _tbotInstance.InstanceSettings.Brain.Transports.MaxSlots,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Transport).Count());
+					RankSlotsPriority ExpeditionsRank = new(Feature.Expeditions,
+						(int) _tbotInstance.InstanceSettings.Expeditions.SlotPriorityLevel,
+						(bool) _tbotInstance.InstanceSettings.Expeditions.Active,
+						(int) _tbotInstance.UserData.slots.ExpTotal,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Expedition).Count());
+					RankSlotsPriority AutoFarmRank = new(Feature.AutoFarm,
+						(int) _tbotInstance.InstanceSettings.AutoFarm.SlotPriorityLevel,
+						(bool) _tbotInstance.InstanceSettings.AutoFarm.Active,
+						(int) _tbotInstance.InstanceSettings.AutoFarm.MaxSlots,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Attack).Count());
+					RankSlotsPriority ColonizeRank = new(Feature.Colonize,
+						(int) _tbotInstance.InstanceSettings.AutoColonize.SlotPriorityLevel,
+						(bool) _tbotInstance.InstanceSettings.AutoColonize.Active,
+						(bool) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.Active ?
+							(int) _tbotInstance.InstanceSettings.AutoColonize.IntensiveResearch.MaxSlots :
+							1,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Colonize).Count());
+					RankSlotsPriority AutoDiscoveryRank = new(Feature.AutoDiscovery,
+						(int) _tbotInstance.InstanceSettings.AutoDiscovery.SlotPriorityLevel,
+						(bool) _tbotInstance.InstanceSettings.AutoDiscovery.Active,
+						(int) _tbotInstance.InstanceSettings.AutoDiscovery.MaxSlots,
+						(int) _tbotInstance.UserData.fleets.Where(fleet => fleet.Mission == Missions.Discovery).Count());
+					RankSlotsPriority presentFeature = new(Feature.Harvest);
+					rankSlotsPriority.Add(BrainRank);
+					rankSlotsPriority.Add(ExpeditionsRank);
+					rankSlotsPriority.Add(AutoFarmRank);
+					rankSlotsPriority.Add(ColonizeRank);
+					rankSlotsPriority.Add(AutoDiscoveryRank);
+					rankSlotsPriority = rankSlotsPriority.OrderBy(r => r.Rank).ToList();
+					string msg = "";
+					int reservedSlots = 0;
+					int MaxSlots = presentFeature.MaxSlots - presentFeature.SlotsUsed;
+					int otherSlots = (int) _tbotInstance.UserData.fleets.Where(fleet => (fleet.Mission != Missions.Transport &&
+							fleet.Mission != Missions.Expedition &&
+							fleet.Mission != Missions.Attack &&
+							fleet.Mission != Missions.Spy &&
+							fleet.Mission != Missions.Colonize &&
+							fleet.Mission != Missions.Discovery)
+						).Count();
+					_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"Main -> {presentFeature.ToString()}");
+					foreach (RankSlotsPriority feature in rankSlotsPriority) {
+						if (feature == presentFeature)
+							continue;
+						_tbotInstance.log(LogLevel.Warning, LogSender.Main, $"{feature.ToString()}");
+						if (feature.Active && feature.HasPriorityOn(presentFeature)) {
+							msg = $"{msg}, {feature.MaxSlots} are reserved for {feature.Feature.ToString()}";
+							reservedSlots += feature.MaxSlots;
+						} else {
+							otherSlots += feature.SlotsUsed;
+						}
+					}
+					if (otherSlots > 0)
+						msg = $"{msg}, {otherSlots} are used for Other";
+					int tempsValue = _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree - reservedSlots - otherSlots - presentFeature.SlotsUsed;
+					tempsValue = tempsValue < 0 ? 0 : tempsValue;
+					DoLog(LogLevel.Information, $"{presentFeature.MaxSlots} slots are reserved for {presentFeature.Feature.ToString()}. Total slots: {_tbotInstance.UserData.slots.Total}. {_tbotInstance.InstanceSettings.General.SlotsToLeaveFree} must remain free{msg}, {tempsValue} are availables");
+					if (reservedSlots + otherSlots > _tbotInstance.UserData.slots.Total - (int) _tbotInstance.InstanceSettings.General.SlotsToLeaveFree) {
+						DoLog(LogLevel.Information, $"Unable to send fleet for {presentFeature.Feature.ToString()}, too many slots are already used/reserved");
+						MaxSlots = 0;
+					} else {
+						MaxSlots = tempsValue;
+					}
 
 					if (dic.Count() == 0)
 						DoLog(LogLevel.Information, "Skipping harvest: there are no fields to harvest.");
+
+					if (dic.Count() > MaxSlots) {
+						var pairsToRemove = dic.Take(dic.Count() - MaxSlots);
+						foreach (var pair in pairsToRemove) {
+							dic.Remove(pair.Key);
+						}
+					}
 
 					foreach (Coordinate destination in dic.Keys) {
 						var fleetId = (int) SendFleetCode.GenericError;

--- a/TBot/instance_settings.json
+++ b/TBot/instance_settings.json
@@ -21,7 +21,7 @@
 			"Height": 1080,
 			"Timezone": "Europe/London",
 			"Lang": "en"
-		}
+		  }
 	},
 	"General": {
 		"Host": "localhost",
@@ -107,16 +107,35 @@
 	},
 	"Brain": {
 		"Active": true,
+		"SlotPriorityLevel": 2,
 		"Transports": {
 			"Active": true,
 			"CargoType": "SmallCargo",
 			"DeutToLeave": 1000000,
 			"RoundResources": true,
+			"SendToTheMoonIfPossible": true,
 			"Origin": {
 				"Galaxy": 3,
 				"System": 333,
 				"Position": 8,
 				"Type": "Moon"
+			},
+			"MaxSlots": 10,
+			"CheckMoonOrPlanetFirst": true,
+			"DoMultipleTransportIsNotEnoughShipButSamePosition": true,
+			"MultipleOrigins": {
+				"Active": false,
+				"OnlyFromMoons": true,
+				"MinimumResourcesToSend": 10000000,
+				"PriorityToProximityOverQuantity": true,
+				"Exclude": [
+					{
+						"Galaxy": 1,
+						"System": 1,
+						"Position": 1,
+						"Type": "Planet"
+					}
+				]			
 			}
 		},
 		"AutoMine": {
@@ -298,6 +317,7 @@
 				"Position": 8,
 				"Type": "Moon"
 			},
+			"TargetAssociateMoon": true,
 			"CargoType": "LargeCargo",
 			"RandomOrder": true,
 			"SkipIfIncomingTransport": true,
@@ -320,6 +340,7 @@
 	},
 	"Expeditions": {
 		"Active": true,
+		"SlotPriorityLevel": 1,
 		"IgnoreSleep": false,
 		"MinWaitNextFleet": 5,
 		"MaxWaitNextFleet": 15,
@@ -366,6 +387,7 @@
 	},
 	"AutoFarm": {
 		"Active": true,
+		"SlotPriorityLevel": 0,
 		"ExcludeMoons": true,
 		"ScanRange": [
 			{
@@ -421,6 +443,7 @@
 	},
 	"AutoColonize": {
 		"Active": true,
+		"SlotPriorityLevel": 0,
 		"Origin": {
 			"Galaxy": 5,
 			"System": 64,
@@ -464,6 +487,7 @@
 	},
 	"AutoDiscovery": {
 		"Active": true,
+		"SlotPriorityLevel": 0,
 		"Origin": {
 			"Galaxy": 5,
 			"System": 64,


### PR DESCRIPTION
**New:**
- AutoRepatriate:
> • allow players to repatriate resources to the moon associated with each planet, instead of a single destination
- Brain:
> • all Brain feature to look the associate moon before the origin before transport resources from a galaxy far far away
> • all Brain feature turn to the associated moon before sending origin's resources
> • add MultipleOrigin to allow `Brain.Transports` to send resources from all celestials
> • transport can now be sent to the moon associated with the target to avoid being scanned by the Phalanx.
- Slots:
> • A priority rating can be assigned to certain feature concerning the use of fleet slots. 1 is the highest priority, then 2, 3, etc... 0 is default, current/old system



**Fix:**
- AutoMine:
> • AutoMine crashes when the mine has already reached maximum level in instance_Settings
- AutoFarm:
> • AutoFarm sent probes to attack despite the presence of solar satellites