### PR TITLE
Add profiles management using Telegram commands

### DIFF
--- a/TBot.Common/Settings/SettingsService.cs
+++ b/TBot.Common/Settings/SettingsService.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -41,6 +42,37 @@ namespace Tbot.Common.Settings {
 				return file;
 			}
 		}
+
+		public static async Task<dynamic> GetMergedSettings(string baseSettingsPath, List<string> overlaySettingsPath) {
+            string baseJson = await GetSettingsFileContents(baseSettingsPath);
+			List<string> overlayJson = new();
+			foreach (var overlay in overlaySettingsPath) {
+				overlayJson.Add(await GetSettingsFileContents(overlay));
+			}
+            return GetMergedSettingsFromContents(baseJson, overlayJson);
+        }
+
+        public static dynamic GetMergedSettingsFromContents(string baseJson, List<string> overlayJson) {
+            var baseObj = JsonConvert.DeserializeObject<JObject>(baseJson) ?? new JObject();
+			var overlayObj = JsonConvert.DeserializeObject<JObject>(overlayJson.First()) ?? new JObject();
+			foreach (var overlay in overlayJson.Skip(1)) {
+				var nextOverlayObj = JsonConvert.DeserializeObject<JObject>(overlay) ?? new JObject();
+				overlayObj.Merge(nextOverlayObj, new JsonMergeSettings {
+					MergeArrayHandling = MergeArrayHandling.Replace,
+					MergeNullValueHandling = MergeNullValueHandling.Ignore
+				});
+			}
+
+            baseObj.Merge(overlayObj, new JsonMergeSettings {
+                MergeArrayHandling = MergeArrayHandling.Replace,
+                MergeNullValueHandling = MergeNullValueHandling.Ignore
+            });
+
+            string mergedJson = baseObj.ToString(Formatting.None);
+            dynamic settings = JsonConvert.DeserializeObject<ExpandoObject>(mergedJson, new ExpandoObjectConverter());
+            settings = ConfigObject.FromExpando(JsonNetAdapter.Transform(settings));
+            return settings;
+        }
 
 		public static bool IsSettingSet(dynamic setting, string property) {
 			try {

--- a/TBot.Ogame.Infrastructure/OgameService.cs
+++ b/TBot.Ogame.Infrastructure/OgameService.cs
@@ -584,6 +584,8 @@ namespace TBot.Ogame.Infrastructure {
 				}
 				parameters.Add(new KeyValuePair<string, string>("mission", ((int) mission).ToString()));
 
+				//if (mission == Missions.Expedition && duration > 0)
+				//	parameters.Add(new KeyValuePair<string, string>("duration", duration.ToString()));
 
 				parameters.Add(new KeyValuePair<string, string>("speed", speed.ToString()));
 				parameters.Add(new KeyValuePair<string, string>("metal", payload.Metal.ToString()));

--- a/TBot/Services/ITBotMain.cs
+++ b/TBot/Services/ITBotMain.cs
@@ -32,5 +32,8 @@ namespace Tbot.Services {
 		Task SendTelegramMessage(string fmt);
 		Task<bool> TelegramSwitch(decimal speed, Celestial attacked = null, bool fromTelegram = false);
 		Task SleepNow(DateTime WakeUpTime);
+		Task ListProfiles();
+		Task LoadProfile(List<string> profileName);
+		Task ResetProfile();
 	}
 }

--- a/TBot/Services/TBotMain.cs
+++ b/TBot/Services/TBotMain.cs
@@ -553,6 +553,129 @@ namespace Tbot.Services {
 			}
 			
 		}
+		public async Task ListProfiles() {
+			string profilesDir = Path.Combine(Path.GetDirectoryName(InstanceSettingsPath), "profiles");
+			string profileList = "Available profiles:\n";
+			if (Directory.Exists(profilesDir)) {
+				var profileFiles = Directory.GetFiles(profilesDir, "*.json");
+				log(LogLevel.Information, LogSender.Tbot, "Available profiles:");
+				foreach (var profileFile in profileFiles) {
+					profileList += $"- {Path.GetFileNameWithoutExtension(profileFile)}\n";
+					log(LogLevel.Information, LogSender.Tbot, $"- {Path.GetFileNameWithoutExtension(profileFile)}");
+				}
+			} else {
+				log(LogLevel.Warning, LogSender.Tbot, "Profiles directory not found.");
+				profileList = "No profiles found.";
+			}
+			await SendTelegramMessage(profileList);
+		}
+		public async Task ListRunningProfiles() {
+			List<string> profiles = userData.runningProfiles;
+			if (profiles.Count <= 0 || profiles == null) {
+				await SendTelegramMessage("No profile is currently running.");
+				return;
+			}
+			string txt = profiles.Count > 1 ? "Profiles currently running:\n" : "Profile currently running:\n";
+			foreach (var profile in profiles) {
+				txt += $"- {profile}\n";
+			}
+			await SendTelegramMessage(txt);
+		}
+		public async Task LoadProfile(List<string> profileName) {
+			for (int i = 0; i < profileName.Count; i++)
+				profileName[i] = profileName[i].Trim();
+
+			log(LogLevel.Information, LogSender.Tbot, "Loading profile detected !");
+			await _settingsReloadSemaphore.WaitAsync();
+
+			try {
+				List<string> profilePath = new();
+				for (int i = 0; i < profileName.Count; i++) {
+					string pPath = Path.Combine(Path.GetDirectoryName(InstanceSettingsPath), "profiles", profileName[i] + ".json");
+					profilePath.Add(pPath);
+					if (!File.Exists(pPath)) {
+						log(LogLevel.Warning, LogSender.Tbot, $"Profile {profileName[i]} not found in the profile folder, loading abandoned.");
+						await SendTelegramMessage($"Profile {profileName[i]} not found in the profile folder, loading abandoned.");
+						return;
+					}
+				}
+				string txt = " "+ profileName.First();
+				foreach (var p in profileName.Skip(1)) {
+					txt += " + "+ p;
+				}
+				if (profilePath.Count > 1)
+					log(LogLevel.Information, LogSender.Tbot, $"Loading profiles{txt}. Waiting workers to complete ongoing activities...");
+				else
+					log(LogLevel.Information, LogSender.Tbot, $"Loading profile{txt}. Waiting workers to complete ongoing activities...");
+				
+				cts.Cancel();
+				foreach (var worker in workers) {
+					log(LogLevel.Information, LogSender.Tbot, $"Stopping feature {worker.Key.ToString()}...");
+					await worker.Value.StopWorker();
+					log(LogLevel.Information, LogSender.Tbot, $"Feature {worker.Key.ToString()} stopped for settings reload!");
+				}
+
+				InstanceSettings = await SettingsService.GetMergedSettings(InstanceSettingsPath, profilePath);
+
+				if (profilePath.Count > 1) {
+					log(LogLevel.Information, LogSender.Tbot, $"Profiles{txt} loaded successfully.");
+					await SendTelegramMessage($"Profiles{txt} loaded successfully.");
+				} else {
+					log(LogLevel.Information, LogSender.Tbot, $"Profile{txt} loaded successfully.");
+					await SendTelegramMessage($"Profile{txt} loaded successfully.");
+				}
+				userData.runningProfiles = profileName;
+
+				_lastReloadFinished = DateTime.Now;
+			} catch (Newtonsoft.Json.JsonException jsonEx) {
+				log(LogLevel.Error, LogSender.Tbot, $"Invalid JSON Format: {jsonEx.Message}");
+				await SendTelegramMessage($"Invalid JSON Format: {jsonEx.Message}");
+			} catch (Exception e) {
+				log(LogLevel.Warning, LogSender.Tbot, $"Exception: {e.Message}");
+				log(LogLevel.Warning, LogSender.Tbot, $"Stacktrace: {e.StackTrace}");
+				await SendTelegramMessage($"Error loading profile: refer to logs.");
+			} finally {
+				if (cts.IsCancellationRequested) {
+					cts = new();
+					// If wakeUp, then all features will be restored
+					await HandleSleepModeAsync(null);
+				}
+				_settingsReloadSemaphore.Release();
+			}
+		}
+		public async Task ResetProfile() {
+
+			log(LogLevel.Information, LogSender.Tbot, "Unloading profile detected! Waiting workers to complete ongoing activities...");
+			await _settingsReloadSemaphore.WaitAsync();
+
+			try {
+				// Wait on feature to be shut down
+				cts.Cancel();
+				foreach (var worker in workers) {
+					log(LogLevel.Information, LogSender.Tbot, $"Stopping feature {worker.Key.ToString()}...");
+					await worker.Value.StopWorker();
+					log(LogLevel.Information, LogSender.Tbot, $"Feature {worker.Key.ToString()} stopped for settings reload!");
+				}
+
+				log(LogLevel.Information, LogSender.Tbot, "Loading origin settings file");
+				await SendTelegramMessage($"Loading origin settings file");
+				InstanceSettings = await SettingsService.GetSettings(InstanceSettingsPath);
+				userData.runningProfiles = new List<string>();
+
+				_lastReloadFinished = DateTime.Now;
+			} catch (Exception e) {
+				log(LogLevel.Warning, LogSender.Tbot, $"Exception: {e.Message}");
+				log(LogLevel.Warning, LogSender.Tbot, $"Stacktrace: {e.StackTrace}");
+				await SendTelegramMessage($"Error loading profile: refer to logs.");
+			} finally {
+				if (cts.IsCancellationRequested) {
+					cts = new();
+					// If wakeUp, then all features will be restored
+					await HandleSleepModeAsync(null);
+				}
+				_settingsReloadSemaphore.Release();
+			}
+		}
 
 		private void InitializeSleepMode() {
 			log(LogLevel.Information, LogSender.Tbot, "Initializing sleep mode...");

--- a/TBot/Services/TelegramMessenger.cs
+++ b/TBot/Services/TelegramMessenger.cs
@@ -276,7 +276,8 @@ namespace Tbot.Services {
 				"/stopautofarm",
 				"/startautofarm",
 				"/stopautodiscovery",
-				"/startautodiscovery"
+				"/startautodiscovery",
+				"/profile"
 			};
 
 			if (update.Type != UpdateType.Message) {
@@ -455,7 +456,8 @@ namespace Tbot.Services {
 								"/stopautofarm - stop autofarm\n" +
 								"/startautofarm - start autofarm\n" +
 								"/stopautodiscovery - stop autodiscovery\n" +
-								"/startautodiscovery - start autodiscovery\n"
+								"/startautodiscovery - start autodiscovery\n" +
+								"/profile - able to load one or multiple profiles. Format: <code>/profile ls/ls-r/reset/laod [profilename] [profilenameX] </code>\n"
 							, ParseMode.Html);
 							return;
 						default:
@@ -1275,6 +1277,38 @@ namespace Tbot.Services {
 								await SendMessage(botClient, message.Chat, celestialStr);
 
 								return;
+
+							case "/profile":
+								if (message.Text.Split(' ').Length < 2) {
+									await SendMessage(botClient, message.Chat, "Mission argument required!");
+									await SendMessage(botClient, message.Chat, "<code>/profile ls</code> (list of profiles)\n<code>/profile ls-r</code> (list of profile currently running)\n<code>/profile load ProfileName</code> (to load a profile)\n<code>/profile load ProfileName1 ProfilName2 ProfilNameX</code> (to merge and load multiple profiles)\n<code>/profile reset</code> (to reset the default profile)");
+									return;
+								}
+
+								switch (message.Text.Split(' ')[1]) {
+									case "ls":
+										await currInstance.ListProfiles();
+										return;
+
+									case "ls-r":
+										await currInstance.ListRunningProfiles();
+										return;
+
+									case "load":
+										List<string> messageParts = message.Text.Split(" ").ToList();
+										messageParts = messageParts.Skip(2).ToList();
+										await currInstance.LoadProfile(messageParts);
+										return;
+
+									case "reset":
+										await currInstance.ResetProfile();
+										return;
+									default:
+										await SendMessage(botClient, message.Chat, "Unknown argument for /profile command!");
+										await SendMessage(botClient, message.Chat, "<code>/profile ls</code> (list of profiles)\n<code>/profile ls-r</code> (list of profile currently running)\n<code>/profile load ProfileName</code> (to load a profile)\n<code>/profile load ProfileName1 ProfilName2 ProfilNameX</code> (to merge and load multiple profiles)\n<code>/profile reset</code> (to reset the default profile)");
+										return;
+								}
+								
 							default:
 								return;
 						}

--- a/TBot/Services/UserData.cs
+++ b/TBot/Services/UserData.cs
@@ -9,33 +9,36 @@ using TBot.Ogame.Infrastructure.Models;
 
 namespace Tbot.Services {
 
-    public class UserData {
-        public Server serverInfo = new();
-        public ServerData serverData;
-        public UserInfo userInfo;
-        public AllianceClass allianceClass;
-        public List<Celestial> celestials;
-        public List<Fleet> fleets;
-        public List<AttackerFleet> attacks;
-        public Slots slots;
-        public Researches researches;
+	// Data required by TBotMain instances
+	public class UserData {
+		public Server serverInfo = new();
+		public ServerData serverData;
+		public UserInfo userInfo;
+		public AllianceClass allianceClass;
+		public List<Celestial> celestials;
+		public List<Fleet> fleets;
+		public List<AttackerFleet> attacks;
+		public Slots slots;
+		public Researches researches;
 
-        public List<FleetSchedule> scheduledFleets;
-        public List<FarmTarget> farmTargets;
-        public Dictionary<Coordinate, DateTime> discoveryBlackList;
-        public float lastDOIR;
-        public float nextDOIR;
-        public Staff staff;
-        public bool isSleeping = false;
+		public List<FleetSchedule> scheduledFleets;
+		public List<FarmTarget> farmTargets;
+		public Dictionary<Coordinate, DateTime> discoveryBlackList;
+		public List<string> runningProfiles;
+		public float lastDOIR;
+		public float nextDOIR;
+		public Staff staff;
+		public bool isSleeping = false;
 
         public int autoFarmLastGalaxy = 0;
         public int autoFarmLastSystem = 0;
 		public int autoFarmLastRangeIndex = 0;
-    }
+	}
 
-    public class TelegramUserData {
+	// Data used by TelegramMessenger binded to TBotMain
+	public class TelegramUserData {
         public Celestial CurrentCelestial;
         public Celestial CurrentCelestialToSave;
-        public Missions Mission = Missions.None;
-    }
+		public Missions Mission = Missions.None;
+	}
 }

--- a/TBot/TBot.csproj
+++ b/TBot/TBot.csproj
@@ -76,6 +76,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="profiles\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TBot.Ogame.Infrastructure\TBot.Ogame.Infrastructure.csproj" />
     <ProjectReference Include="..\TBot.WebUI\TBot.WebUI.csproj" />
   </ItemGroup>

--- a/TBot/profiles/autofarm.json
+++ b/TBot/profiles/autofarm.json
@@ -1,0 +1,37 @@
+{
+	"General": {
+		"SlotPriorityLevel": {
+			"AutoFarm": 0
+		}
+	},
+	"Brain": {
+		"Active": false
+    },
+	"Expeditions": {
+		"Active": false
+    },
+	"AutoFarm": {
+		"Active": true,
+		"ScanRange": [
+			{
+				"Galaxy": 3,
+				"StartSystem": 14,
+				"EndSystem": 114
+			}
+		],
+		"Origin": [
+			{
+				"Galaxy": 5,
+				"System": 64,
+				"Position": 8,
+				"Type": "Planet"
+			}
+		]
+	},
+	"AutoColonize": {
+		"Active": false
+	},
+	"AutoDiscovery": {
+		"Active": false
+	}
+}

--- a/TBot/profiles/brainlf.json
+++ b/TBot/profiles/brainlf.json
@@ -1,0 +1,29 @@
+{
+	"Brain": {
+		"Active": true,
+		"AutoMine": {
+			"Active": false
+		},
+		"LifeformAutoMine": {
+			"Active": true
+		},
+		"LifeformAutoResearch": {
+			"Active": true
+		},
+		"AutoResearch": {
+			"Active": false
+		}
+    },
+	"Expeditions": {
+		"Active": false
+	},
+	"AutoFarm": {
+		"Active": false
+	},
+	"AutoColonize": {
+		"Active": false
+	},
+	"AutoDiscovery": {
+		"Active": false
+	}
+}

--- a/TBot/profiles/brainnolf.json
+++ b/TBot/profiles/brainnolf.json
@@ -1,0 +1,29 @@
+{
+	"Brain": {
+		"Active": true,
+		"AutoMine": {
+			"Active": true
+		},
+		"LifeformAutoMine": {
+			"Active": false
+		},
+		"LifeformAutoResearch": {
+			"Active": false
+		},
+		"AutoResearch": {
+			"Active": true
+		}
+    },
+	"Expeditions": {
+		"Active": false
+	},
+	"AutoFarm": {
+		"Active": false
+	},
+	"AutoColonize": {
+		"Active": false
+	},
+	"AutoDiscovery": {
+		"Active": false
+	}
+}

--- a/TBot/profiles/buildDef.json
+++ b/TBot/profiles/buildDef.json
@@ -1,0 +1,16 @@
+{
+	"Brain": {
+		"Active": true,
+		"AutoDefence": {
+			"Active": true,
+			"DefenceToReach": {
+				"RocketLauncher": 200000,
+				"HeavyLaser": 20000,
+				"GaussCannon": 2000,
+				"PlasmaTurret": 2000,
+				"SmallShieldDome": true,
+				"LargeShieldDome": true
+			}
+		}
+	}
+}

--- a/TBot/profiles/sleeper.json
+++ b/TBot/profiles/sleeper.json
@@ -1,0 +1,60 @@
+{
+	"SleepMode": {
+		"Active": true,
+		"GoToSleep": "8:35",
+		"WakeUp": "8:23",
+		"PreventIfThereAreFleets": true,
+		"TelegramMessenger": {
+			"Active": false
+		},
+		"AutoFleetSave": {
+			"Active": true,
+			"OnlyMoons": true,
+			"DeutToLeave": 200000,
+			"Recall": true,
+			"DefaultMission": "Deploy"
+		}
+	},
+	"Defender": {
+		"Active": true
+	},
+	"Brain": {
+		"Active": true,
+		"AutoMine": {
+			"Active": false
+		},
+		"LifeformAutoMine": {
+			"Active": false
+		},
+		"LifeformAutoResearch": {
+			"Active": false
+		},
+		"AutoResearch": {
+			"Active": false
+		},
+		"AutoCargo": {
+			"Active": false
+		},
+		"AutoDefence": {
+			"Active": false
+		},
+		"AutoRepatriate": {
+			"Active": false
+		},
+		"BuyOfferOfTheDay": {
+            "Active": true
+        }
+    },
+	"Expeditions": {
+		"Active": false
+	},
+	"AutoFarm": {
+		"Active": false
+	},
+	"AutoColonize": {
+		"Active": false
+	},
+	"AutoDiscovery": {
+		"Active": false
+	}
+}


### PR DESCRIPTION
Add profiles management using Telegram commands.

- The User can create and customize profiles and quickly switch between them without editing the main settings.
- Profiles can be loaded individually or merged.
- Profiles files must keep the same structure as `instance_settings.json`.
- Profile files should contain only the value to be modified.
- If multiple profiles are load at the same time and edit the same value, the profile+1 overwrite the previous one.

The new generate settings (one or multiples merged profiles) is discarded when TBot start, or if `instance_settings.json` is edited.

Telegram Commands:
- `/profile ls` : list of profiles
- `/profile ls-r` : list of profile currently running
- `/profile load ProfileName` : load a profile named **ProfileName**
- `/profile load ProfileName1 ProfileName2 ProfileNameX` : load and merge multiple profiles
- `/profile reset` : reset the default settings (`instance_settings.json`)