### PR TITLE
Add Empire view feature availability

### DIFF
--- a/TBot.Ogame.Infrastructure/IOgameService.cs
+++ b/TBot.Ogame.Infrastructure/IOgameService.cs
@@ -44,7 +44,7 @@ namespace TBot.Ogame.Infrastructure {
 		Task<GalaxyInfo> GetGalaxyInfo(int galaxy, int system);
 		Task<LFBuildings> GetLFBuildings(Celestial celestial);
 		Task<LFTechs> GetLFTechs(Celestial celestial);
-		Task<LFBonuses> GetLFBonuses(Celestial celestial);
+		Task<LFBonuses> GetLFBonuses();
 		Task<Moon> GetMoon(Moon moon);
 		Task<List<Moon>> GetMoons();
 		Task<string> GetOgamedIP();
@@ -73,6 +73,8 @@ namespace TBot.Ogame.Infrastructure {
 		Task<string> GetTbotIP();
 		Task<Techs> GetTechs(Celestial celestial);
 		Task<CharacterClass> GetUserClass();
+		Task<List<Celestial>> GetEmpirePlanets();
+		Task<List<Celestial>> GetEmpireMoons();
 		Task<UserInfo> GetUserInfo();
 		Task<string> GetUsername();
 		Task<bool> HasAdmiral();
@@ -84,7 +86,6 @@ namespace TBot.Ogame.Infrastructure {
 		bool IsPortAvailable(string host, int port = 8080);
 		Task<bool> IsUnderAttack();
 		Task<bool> IsVacationMode();
-		Task JumpGate(Celestial origin, Celestial destination, Ships ships);
 		Task<bool> SendDiscovery(Celestial origin, Coordinate coords);
 		void KillOgamedExecutable(CancellationToken ct = default);
 		Task Login();

--- a/TBot.Ogame.Infrastructure/Models/Celestial.cs
+++ b/TBot.Ogame.Infrastructure/Models/Celestial.cs
@@ -29,6 +29,7 @@ namespace TBot.Ogame.Infrastructure.Models {
 		public ResourceSettings ResourceSettings { get; set; }
 		public ResourcesProduction ResourcesProduction { get; set; }
 		public Debris Debris { get; set; }
+		public Researches Researches { get; set; }
 
 		public override string ToString() {
 			return $"{Name} {Coordinate.ToString()}";

--- a/TBot.Ogame.Infrastructure/OgameService.cs
+++ b/TBot.Ogame.Infrastructure/OgameService.cs
@@ -390,6 +390,310 @@ namespace TBot.Ogame.Infrastructure {
 			return await GetAsync<CharacterClass>("/bot/character-class");
 		}
 
+		private Celestial ParseEmpireEntry(JObject obj, Celestials type, LFBonuses lfBonuses = null) {
+			Celestial cel = new();
+			cel.ID = obj["id"]?.Value<int>() ?? 0;
+			cel.Name = obj["name"]?.Value<string>() ?? "";
+			cel.Coordinate = new Coordinate {
+				Galaxy = obj["galaxy"]?.Value<int>() ?? 0,
+				System = obj["system"]?.Value<int>() ?? 0,
+				Position = obj["position"]?.Value<int>() ?? 0,
+				Type = type
+			};
+			string fieldUsedStr = obj["fieldUsed"]?.Value<string>();
+			int built = 0;
+			int.TryParse(fieldUsedStr, out built);
+			string fieldMaxStr = obj["fieldMax"]?.Value<string>();
+			int total = 0;
+			int.TryParse(fieldMaxStr, out total);
+			cel.Fields = new Fields {
+				Built = built,
+				Total = total
+			};
+			cel.Resources = new Resources {
+				Metal = obj["metal"]?.Value<long>() ?? 0,
+				Crystal = obj["crystal"]?.Value<long>() ?? 0,
+				Deuterium = obj["deuterium"]?.Value<long>() ?? 0,
+				Energy = obj["production"]?["hourly"]?["3"]?.Value<long>() ?? 0,
+				Food = obj["food"]?.Value<long>() ?? 0,
+				Population = obj["population"]?.Value<long>() ?? 0
+			};
+			cel.Ships = new Ships {
+				LightFighter = obj["204"]?.Value<int>() ?? 0,
+				HeavyFighter = obj["205"]?.Value<int>() ?? 0,
+				Cruiser = obj["206"]?.Value<int>() ?? 0,
+				Battleship = obj["207"]?.Value<int>() ?? 0,
+				Battlecruiser = obj["215"]?.Value<int>() ?? 0,
+				Bomber = obj["211"]?.Value<int>() ?? 0,
+				Destroyer = obj["213"]?.Value<int>() ?? 0,
+				Deathstar = obj["214"]?.Value<int>() ?? 0,
+				SmallCargo = obj["202"]?.Value<int>() ?? 0,
+				LargeCargo = obj["203"]?.Value<int>() ?? 0,
+				ColonyShip = obj["208"]?.Value<int>() ?? 0,
+				Recycler = obj["209"]?.Value<int>() ?? 0,
+				EspionageProbe = obj["210"]?.Value<int>() ?? 0,
+				SolarSatellite = obj["212"]?.Value<int>() ?? 0,
+				Crawler = obj["217"]?.Value<int>() ?? 0,
+				Reaper = obj["218"]?.Value<int>() ?? 0,
+				Pathfinder = obj["219"]?.Value<int>() ?? 0
+			};
+			cel.Defences = new Defences {
+				RocketLauncher = obj["401"]?.Value<int>() ?? 0,
+				LightLaser = obj["402"]?.Value<int>() ?? 0,
+				HeavyLaser = obj["403"]?.Value<int>() ?? 0,
+				GaussCannon = obj["404"]?.Value<int>() ?? 0,
+				IonCannon = obj["405"]?.Value<int>() ?? 0,
+				PlasmaTurret = obj["406"]?.Value<int>() ?? 0,
+				SmallShieldDome = obj["407"]?.Value<int>() ?? 0,
+				LargeShieldDome = obj["408"]?.Value<int>() ?? 0,
+				AntiBallisticMissiles = obj["502"]?.Value<int>() ?? 0,
+				InterplanetaryMissiles = obj["503"]?.Value<int>() ?? 0
+			};
+			cel.Buildings = new Buildings {
+				MetalMine = obj["1"]?.Value<int>() ?? 0,
+				CrystalMine = obj["2"]?.Value<int>() ?? 0,
+				DeuteriumSynthesizer = obj["3"]?.Value<int>() ?? 0,
+				SolarPlant = obj["4"]?.Value<int>() ?? 0,
+				FusionReactor = obj["12"]?.Value<int>() ?? 0,
+				SolarSatellite = obj["212"]?.Value<int>() ?? 0,
+				MetalStorage = obj["22"]?.Value<int>() ?? 0,
+				CrystalStorage = obj["23"]?.Value<int>() ?? 0,
+				DeuteriumTank = obj["24"]?.Value<int>() ?? 0
+			};
+			cel.LFBuildings = new LFBuildings {
+				ResidentialSector = obj["11101"]?.Value<int>() ?? 0,
+				BiosphereFarm = obj["11102"]?.Value<int>() ?? 0,
+				ResearchCentre = obj["11103"]?.Value<int>() ?? 0,
+				AcademyOfSciences = obj["11104"]?.Value<int>() ?? 0,
+				NeuroCalibrationCentre = obj["11105"]?.Value<int>() ?? 0,
+				HighEnergySmelting = obj["11106"]?.Value<int>() ?? 0,
+				FoodSilo = obj["11107"]?.Value<int>() ?? 0,
+				FusionPoweredProduction = obj["11108"]?.Value<int>() ?? 0,
+				Skyscraper = obj["11109"]?.Value<int>() ?? 0,
+				BiotechLab = obj["11110"]?.Value<int>() ?? 0,
+				Metropolis = obj["11111"]?.Value<int>() ?? 0,
+				PlanetaryShield = obj["11112"]?.Value<int>() ?? 0,
+				MeditationEnclave = obj["12101"]?.Value<int>() ?? 0,
+				CrystalFarm = obj["12102"]?.Value<int>() ?? 0,
+				RuneTechnologium = obj["12103"]?.Value<int>() ?? 0,
+				RuneForge = obj["12104"]?.Value<int>() ?? 0,
+				Oriktorium = obj["12105"]?.Value<int>() ?? 0,
+				MagmaForge = obj["12106"]?.Value<int>() ?? 0,
+				DisruptionChamber = obj["12107"]?.Value<int>() ?? 0,
+				Megalith = obj["12108"]?.Value<int>() ?? 0,
+				CrystalRefinery = obj["12109"]?.Value<int>() ?? 0,
+				DeuteriumSynthesiser = obj["12110"]?.Value<int>() ?? 0,
+				MineralResearchCentre = obj["12111"]?.Value<int>() ?? 0,
+				AdvancedRecyclingPlant = obj["12112"]?.Value<int>() ?? 0,				
+				AssemblyLine = obj["13101"]?.Value<int>() ?? 0,
+				FusionCellFactory = obj["13102"]?.Value<int>() ?? 0,
+				RoboticsResearchCentre = obj["13103"]?.Value<int>() ?? 0,
+				UpdateNetwork = obj["13104"]?.Value<int>() ?? 0,
+				QuantumComputerCentre = obj["13105"]?.Value<int>() ?? 0,
+				AutomatisedAssemblyCentre = obj["13106"]?.Value<int>() ?? 0,
+				HighPerformanceTransformer = obj["13107"]?.Value<int>() ?? 0,
+				MicrochipAssemblyLine = obj["13108"]?.Value<int>() ?? 0,
+				ProductionAssemblyHall = obj["13109"]?.Value<int>() ?? 0,
+				HighPerformanceSynthesiser = obj["13110"]?.Value<int>() ?? 0,
+				ChipMassProduction = obj["13111"]?.Value<int>() ?? 0,
+				NanoRepairBots = obj["13112"]?.Value<int>() ?? 0,				
+				Sanctuary = obj["14101"]?.Value<int>() ?? 0,
+				AntimatterCondenser = obj["14102"]?.Value<int>() ?? 0,
+				VortexChamber = obj["14103"]?.Value<int>() ?? 0,
+				HallsOfRealisation = obj["14104"]?.Value<int>() ?? 0,
+				ForumOfTranscendence = obj["14105"]?.Value<int>() ?? 0,
+				AntimatterConvector = obj["14106"]?.Value<int>() ?? 0,
+				CloningLaboratory = obj["14107"]?.Value<int>() ?? 0,
+				ChrysalisAccelerator = obj["14108"]?.Value<int>() ?? 0,
+				BioModifier = obj["14109"]?.Value<int>() ?? 0,
+				PsionicModulator = obj["14110"]?.Value<int>() ?? 0,
+				ShipManufacturingHall = obj["14111"]?.Value<int>() ?? 0,
+				SupraRefractor = obj["14112"]?.Value<int>() ?? 0
+			};
+			cel.LFTechs = new LFTechs {
+				IntergalacticEnvoys = obj["11201"]?.Value<int>() ?? 0,
+				HighPerformanceExtractors = obj["11202"]?.Value<int>() ?? 0,
+				FusionDrives = obj["11203"]?.Value<int>() ?? 0,
+				StealthFieldGenerator = obj["11204"]?.Value<int>() ?? 0,
+				OrbitalDen = obj["11205"]?.Value<int>() ?? 0,
+				ResearchAI = obj["11206"]?.Value<int>() ?? 0,
+				HighPerformanceTerraformer = obj["11207"]?.Value<int>() ?? 0,
+				EnhancedProductionTechnologies = obj["11208"]?.Value<int>() ?? 0,
+				LightFighterMkII = obj["11209"]?.Value<int>() ?? 0,
+				CruiserMkII = obj["11210"]?.Value<int>() ?? 0,
+				ImprovedLabTechnology = obj["11211"]?.Value<int>() ?? 0,
+				PlasmaTerraformer = obj["11212"]?.Value<int>() ?? 0,
+				LowTemperatureDrives = obj["11213"]?.Value<int>() ?? 0,
+				BomberMkII = obj["11214"]?.Value<int>() ?? 0,
+				DestroyerMkII = obj["11215"]?.Value<int>() ?? 0,
+				BattlecruiserMkII = obj["11216"]?.Value<int>() ?? 0,
+				RobotAssistants = obj["11217"]?.Value<int>() ?? 0,
+				Supercomputer = obj["11218"]?.Value<int>() ?? 0,
+				VolcanicBatteries = obj["12201"]?.Value<int>() ?? 0,
+				AcousticScanning = obj["12202"]?.Value<int>() ?? 0,
+				HighEnergyPumpSystems = obj["12203"]?.Value<int>() ?? 0,
+				CargoHoldExpansionCivilianShips = obj["12204"]?.Value<int>() ?? 0,
+				MagmaPoweredProduction = obj["12205"]?.Value<int>() ?? 0,
+				GeothermalPowerPlants = obj["12206"]?.Value<int>() ?? 0,
+				DepthSounding = obj["12207"]?.Value<int>() ?? 0,
+				IonCrystalEnhancementHeavyFighter = obj["12208"]?.Value<int>() ?? 0,
+				ImprovedStellarator = obj["12209"]?.Value<int>() ?? 0,
+				HardenedDiamondDrillHeads = obj["12210"]?.Value<int>() ?? 0,
+				SeismicMiningTechnology = obj["12211"]?.Value<int>() ?? 0,
+				MagmaPoweredPumpSystems = obj["12212"]?.Value<int>() ?? 0,
+				IonCrystalModules = obj["12213"]?.Value<int>() ?? 0,
+				OptimisedSiloConstructionMethod = obj["12214"]?.Value<int>() ?? 0,
+				DiamondEnergyTransmitter = obj["12215"]?.Value<int>() ?? 0,
+				ObsidianShieldReinforcement = obj["12216"]?.Value<int>() ?? 0,
+				RuneShields = obj["12217"]?.Value<int>() ?? 0,
+				RocktalCollectorEnhancement = obj["12218"]?.Value<int>() ?? 0,
+				CatalyserTechnology = obj["13201"]?.Value<int>() ?? 0,
+				PlasmaDrive = obj["13202"]?.Value<int>() ?? 0,
+				EfficiencyModule = obj["13203"]?.Value<int>() ?? 0,
+				DepotAI = obj["13204"]?.Value<int>() ?? 0,
+				GeneralOverhaulLightFighter = obj["13205"]?.Value<int>() ?? 0,
+				AutomatedTransportLines = obj["13206"]?.Value<int>() ?? 0,
+				ImprovedDroneAI = obj["13207"]?.Value<int>() ?? 0,
+				ExperimentalRecyclingTechnology = obj["13208"]?.Value<int>() ?? 0,
+				GeneralOverhaulCruiser = obj["13209"]?.Value<int>() ?? 0,
+				SlingshotAutopilot = obj["13210"]?.Value<int>() ?? 0,
+				HighTemperatureSuperconductors = obj["13211"]?.Value<int>() ?? 0,
+				GeneralOverhaulBattleship = obj["13212"]?.Value<int>() ?? 0,
+				ArtificialSwarmIntelligence = obj["13213"]?.Value<int>() ?? 0,
+				GeneralOverhaulBattlecruiser = obj["13214"]?.Value<int>() ?? 0,
+				GeneralOverhaulBomber = obj["13215"]?.Value<int>() ?? 0,
+				GeneralOverhaulDestroyer = obj["13216"]?.Value<int>() ?? 0,
+				ExperimentalWeaponsTechnology = obj["13217"]?.Value<int>() ?? 0,
+				MechanGeneralEnhancement = obj["13218"]?.Value<int>() ?? 0,
+				HeatRecovery = obj["14201"]?.Value<int>() ?? 0,
+				SulphideProcess = obj["14202"]?.Value<int>() ?? 0,
+				PsionicNetwork = obj["14203"]?.Value<int>() ?? 0,
+				TelekineticTractorBeam = obj["14204"]?.Value<int>() ?? 0,
+				EnhancedSensorTechnology = obj["14205"]?.Value<int>() ?? 0,
+				NeuromodalCompressor = obj["14206"]?.Value<int>() ?? 0,
+				NeuroInterface = obj["14207"]?.Value<int>() ?? 0,
+				InterplanetaryAnalysisNetwork = obj["14208"]?.Value<int>() ?? 0,
+				OverclockingHeavyFighter = obj["14209"]?.Value<int>() ?? 0,
+				TelekineticDrive = obj["14210"]?.Value<int>() ?? 0,
+				SixthSense = obj["14211"]?.Value<int>() ?? 0,
+				Psychoharmoniser = obj["14212"]?.Value<int>() ?? 0,
+				EfficientSwarmIntelligence = obj["14213"]?.Value<int>() ?? 0,
+				OverclockingLargeCargo = obj["14214"]?.Value<int>() ?? 0,
+				GravitationSensors = obj["14215"]?.Value<int>() ?? 0,
+				OverclockingBattleship = obj["14216"]?.Value<int>() ?? 0,
+				PsionicShieldMatrix = obj["14217"]?.Value<int>() ?? 0,
+				KaeleshDiscovererEnhancement = obj["14218"]?.Value<int>() ?? 0
+			};
+			if (lfBonuses != null)
+				cel.LFBonuses = lfBonuses;
+			cel.Facilities = new Facilities {
+				AllianceDepot = obj["34"]?.Value<int>() ?? 0,
+				RoboticsFactory = obj["14"]?.Value<int>() ?? 0,
+				Shipyard = obj["21"]?.Value<int>() ?? 0,
+				ResearchLab = obj["31"]?.Value<int>() ?? 0,
+				MissileSilo = obj["44"]?.Value<int>() ?? 0,
+				NaniteFactory = obj["15"]?.Value<int>() ?? 0,
+				Terraformer = obj["33"]?.Value<int>() ?? 0,
+				SpaceDock = obj["36"]?.Value<int>() ?? 0,
+				LunarBase = obj["41"]?.Value<int>() ?? 0,
+				SensorPhalanx = obj["42"]?.Value<int>() ?? 0,
+				JumpGate = obj["43"]?.Value<int>() ?? 0
+			};
+			cel.Constructions = new();
+			cel.ResourcesProduction = new ResourcesProduction {
+				Metal = new Resource {
+					Available = obj["metal"]?.Value<long>() ?? 0,
+					StorageCapacity = obj["metalStorage"]?.Value<long>() ?? 0,
+					CurrentProduction = obj["production"]?["hourly"]?["0"]?.Value<long>() ?? 0
+				},
+				Crystal = new Resource {
+					Available = obj["crystal"]?.Value<long>() ?? 0,
+					StorageCapacity = obj["crystalStorage"]?.Value<long>() ?? 0,
+					CurrentProduction = obj["production"]?["hourly"]?["1"]?.Value<long>() ?? 0
+				},
+				Deuterium = new Resource {
+					Available = obj["deuterium"]?.Value<long>() ?? 0,
+					StorageCapacity = obj["deuteriumStorage"]?.Value<long>() ?? 0,
+					CurrentProduction = obj["production"]?["hourly"]?["2"]?.Value<long>() ?? 0
+				},
+				Food = new Food {
+					Available = obj["food"]?.Value<long>() ?? 0,
+					StorageCapacity = obj["foodStorage"]?.Value<long>() ?? 0
+				},
+				Population = new Population {
+					Available = obj["population"]?.Value<long>() ?? 0,
+					LivingSpace = obj["populationStorage"]?.Value<long>() ?? 0,
+					BunkerSpace = obj["populationHide"]?.Value<long>() ?? 0
+				},
+				Energy = new Energy {
+					Available = obj["production"]?["hourly"]?["3"]?.Value<long>() ?? 0
+				}
+			};
+			cel.Researches = new Researches {
+				EspionageTechnology = obj["106"]?.Value<int>() ?? 0,
+				ComputerTechnology = obj["108"]?.Value<int>() ?? 0,
+				WeaponsTechnology = obj["109"]?.Value<int>() ?? 0,
+				ShieldingTechnology = obj["110"]?.Value<int>() ?? 0,
+				ArmourTechnology = obj["111"]?.Value<int>() ?? 0,
+				EnergyTechnology = obj["113"]?.Value<int>() ?? 0,
+				HyperspaceTechnology = obj["114"]?.Value<int>() ?? 0,
+				CombustionDrive = obj["115"]?.Value<int>() ?? 0,
+				ImpulseDrive = obj["117"]?.Value<int>() ?? 0,
+				HyperspaceDrive = obj["118"]?.Value<int>() ?? 0,
+				LaserTechnology = obj["120"]?.Value<int>() ?? 0,
+				IonTechnology = obj["121"]?.Value<int>() ?? 0,
+				PlasmaTechnology = obj["122"]?.Value<int>() ?? 0,
+				IntergalacticResearchNetwork = obj["123"]?.Value<int>() ?? 0,
+				Astrophysics = obj["124"]?.Value<int>() ?? 0,
+				GravitonTechnology = obj["199"]?.Value<int>() ?? 0
+			};
+
+			foreach (var prop in obj.Properties()) {
+				if (!prop.Name.EndsWith("_html", StringComparison.OrdinalIgnoreCase))
+					continue;
+				if (prop.Value.Type != JTokenType.String)
+					continue;
+				string html = prop.Value.Value<string>();
+				if (!html.Contains("align='absmiddle'"))
+					continue;
+				string rawName = prop.Name.Substring(0, prop.Name.Length - "_html".Length);
+				if (!int.TryParse(rawName, out int id))
+					continue;
+				
+				if (Enum.IsDefined(typeof(Buildables), id)) {
+					if (typeof(Defences).GetProperty(((Buildables)id).ToString()) != null || typeof(Ships).GetProperty(((Buildables)id).ToString()) != null)
+						continue;
+					if (typeof(Researches).GetProperty(((Buildables)id).ToString()) != null)
+						cel.Constructions.ResearchID = id;
+					else
+						cel.Constructions.BuildingID = id;
+				} else if (Enum.IsDefined(typeof(LFBuildables), id)) {
+					cel.Constructions.LFBuildingID = id;
+				} else if (Enum.IsDefined(typeof(LFTechno), id)) {
+					cel.Constructions.LFResearchID = id;
+				}
+			}
+			return cel;
+		}
+		public async Task<List<Celestial>> GetEmpirePlanets() {
+			List<Celestial> result = new();
+			var empire = await GetAsync<JObject>("/bot/empire/type/0");
+			LFBonuses lfBonuses = await GetLFBonuses();
+			if (empire["planets"] is JArray planets)
+				foreach (JObject planet in planets)
+					result.Add(ParseEmpireEntry(planet, Celestials.Planet, lfBonuses));
+			return result;
+		}
+		public async Task<List<Celestial>> GetEmpireMoons() {
+			List<Celestial> result = new();
+			var empire = await GetAsync<JObject>("/bot/empire/type/1");
+			LFBonuses lfBonuses = await GetLFBonuses();
+			if (empire["planets"] is JArray planets)
+				foreach (JObject planet in planets)
+					result.Add(ParseEmpireEntry(planet, Celestials.Moon, lfBonuses));
+			return result;
+		}
+
 		public async Task<List<Planet>> GetPlanets() {
 			return await GetAsync<List<Planet>>("/bot/planets");
 		}
@@ -440,7 +744,7 @@ namespace TBot.Ogame.Infrastructure {
 			return await GetAsync<LFBuildings>($"/bot/planets/{celestial.ID}/lifeform-buildings");
 		}
 
-		public async Task<LFBonuses> GetLFBonuses(Celestial celestial) {
+		public async Task<LFBonuses> GetLFBonuses() {
 			//return await GetAsync<LFBonuses>($"/bot/planets/{celestial.ID}/lifeform-bonuses");
 			return await GetAsync<LFBonuses>($"/bot/lfbonuses");
 		}

--- a/TBot/Workers/ITBotOgamedBridge.cs
+++ b/TBot/Workers/ITBotOgamedBridge.cs
@@ -10,6 +10,9 @@ namespace Tbot.Workers {
 		Task<bool> CheckCelestials();
 		Task<DateTime> GetDateTime();
 		Task<List<Celestial>> GetPlanets();
+		Task<List<Celestial>> GetEmpire();
+		Task<List<Celestial>> GetEmpirePlanets();
+		Task<List<Celestial>> GetEmpireMoons();
 		Task<List<Celestial>> UpdateCelestials();
 		Task<List<GalaxyInfo>> UpdateGalaxyInfos();
 		Task<Celestial> UpdatePlanet(Celestial planet, UpdateTypes UpdateTypes = UpdateTypes.Full);

--- a/TBot/Workers/TBotOgamedBridge.cs
+++ b/TBot/Workers/TBotOgamedBridge.cs
@@ -64,7 +64,7 @@ namespace Tbot.Workers
 						planet.LFTechs = await ogameService.GetLFTechs(planet);
 						break;
 					case UpdateTypes.LFBonuses:
-						planet.LFBonuses = await ogameService.GetLFBonuses(planet);
+						planet.LFBonuses = await ogameService.GetLFBonuses();
 						break;
 					case UpdateTypes.Ships:
 						planet.Ships = await ogameService.GetShips(planet);
@@ -141,6 +141,46 @@ namespace Tbot.Workers
 				_tbotInstance.log(LogLevel.Debug, LogSender.Tbot, $"UpdatePlanets({UpdateTypes.ToString()}) Exception: {e.Message}");
 				_tbotInstance.log(LogLevel.Warning, LogSender.Tbot, $"Stacktrace: {e.StackTrace}");
 				return newPlanets;
+			}
+		}
+		public async Task<List<Celestial>> GetEmpire() {
+			List<Celestial> localPlanets = _tbotInstance.UserData.celestials ?? new();
+			try {
+				List<Celestial> ogamedPlanets = await _ogameService.GetEmpirePlanets();
+				ogamedPlanets.AddRange(await _ogameService.GetEmpireMoons());
+				if (ogamedPlanets.Count() != 0)
+					localPlanets = ogamedPlanets.ToList();
+				return localPlanets;
+			} catch (Exception e) {
+				_tbotInstance.log(LogLevel.Debug, LogSender.Tbot, $"GetEmpire() Exception: {e.Message}");
+				_tbotInstance.log(LogLevel.Warning, LogSender.Tbot, $"Stacktrace: {e.StackTrace}");
+				return localPlanets;
+			}
+		}
+		public async Task<List<Celestial>> GetEmpirePlanets() {
+			List<Celestial> localPlanets = _tbotInstance.UserData.celestials.Where(c => c.Coordinate.Type == Celestials.Planet).ToList() ?? new();
+			try {
+				List<Celestial> ogamedPlanets = await _ogameService.GetEmpirePlanets();
+				if (ogamedPlanets.Count() != 0)
+					localPlanets = ogamedPlanets.ToList();
+				return localPlanets;
+			} catch (Exception e) {
+				_tbotInstance.log(LogLevel.Debug, LogSender.Tbot, $"GetEmpirePlanets() Exception: {e.Message}");
+				_tbotInstance.log(LogLevel.Warning, LogSender.Tbot, $"Stacktrace: {e.StackTrace}");
+				return localPlanets;
+			}
+		}
+		public async Task<List<Celestial>> GetEmpireMoons() {
+			List<Celestial> localPlanets = _tbotInstance.UserData.celestials.Where(c => c.Coordinate.Type == Celestials.Moon).ToList() ?? new();
+			try {
+				List<Celestial> ogamedPlanets = await _ogameService.GetEmpireMoons();
+				if (ogamedPlanets.Count() != 0)
+					localPlanets = ogamedPlanets.ToList();
+				return localPlanets;
+			} catch (Exception e) {
+				_tbotInstance.log(LogLevel.Debug, LogSender.Tbot, $"GetEmpireMoons() Exception: {e.Message}");
+				_tbotInstance.log(LogLevel.Warning, LogSender.Tbot, $"Stacktrace: {e.StackTrace}");
+				return localPlanets;
 			}
 		}
 


### PR DESCRIPTION
Developers can now use data from the Empire view to reduce the number of request and combine multiple types of updates into a single one.

- `GetEmpire();` to update all Celestials
- `GetEmpirePlanets();` to update all planets
- `GetEmpireMoons();` to update all moons

Warning: Shipbuilding is ignored